### PR TITLE
Consistent variable names and SpecURI

### DIFF
--- a/pybio/core/training/classic_fit.py
+++ b/pybio/core/training/classic_fit.py
@@ -1,14 +1,14 @@
-from pybio.spec.spec_types import ModelSpec
+from pybio.spec.node import Model
 from pybio.spec.utils import get_instance
 
 
-def classic_fit(model_spec: ModelSpec, start: int = 0, batch_size: int = 1):
+def classic_fit(pybio_model: Model, start: int = 0, batch_size: int = 1):
     """classic fit a la 'model.fit(X, y)'"""
 
-    model = get_instance(model_spec)
-    reader = get_instance(model_spec.spec.training.setup.reader)
-    sampler = get_instance(model_spec.spec.training.setup.sampler, reader=reader)
+    model = get_instance(pybio_model)
+    reader = get_instance(pybio_model.spec.training.setup.reader)
+    sampler = get_instance(pybio_model.spec.training.setup.sampler, reader=reader)
     X, y = sampler[start, batch_size]
     model.fit([X], [y])
     return model
-    # todo: save model weights
+    # todo: save/return model weights/checkpoint?!?

--- a/pybio/core/transformations/base.py
+++ b/pybio/core/transformations/base.py
@@ -1,7 +1,7 @@
 from typing import List, Sequence, Tuple, Optional, Union
 
 from pybio.core.array import PyBioArray
-from pybio.spec.spec_types import InputArray, OutputArray
+from pybio.spec.node import InputArray, OutputArray
 
 
 class ApplyToAll:

--- a/pybio/spec/__init__.py
+++ b/pybio/spec/__init__.py
@@ -1,4 +1,3 @@
 __version__ = "0.1.0"
 
-from pybio.spec.schema import load_model_spec, ModelSpec, SamplerSpec, ReaderSpec, TransformationSpec
-from .utils import load_spec
+from .utils import load_spec_and_kwargs, load_model

--- a/pybio/spec/exceptions.py
+++ b/pybio/spec/exceptions.py
@@ -4,6 +4,9 @@ from marshmallow import ValidationError
 class PyBioException(Exception):
     pass
 
+class PyBioMissingKwargException(PyBioException, TypeError):
+    pass
+
 
 class PyBioValidationException(PyBioException, ValidationError):
     pass

--- a/pybio/spec/fields.py
+++ b/pybio/spec/fields.py
@@ -1,25 +1,16 @@
 import importlib
 from urllib.parse import urlparse, ParseResult
 import pathlib
-import sys
 import uuid
-import requests
-import subprocess
 import typing
-import yaml
-import contextlib
 
 from marshmallow.fields import Str, Nested, List, Dict, Integer, Float, Tuple, ValidationError  # noqa
 
-from pybio.spec.exceptions import InvalidDoiException, PyBioValidationException
+from pybio.spec.exceptions import PyBioValidationException
 from pybio.spec import spec_types
-#import MagicTensorsValue, MagicShapeValue, Importable, URI
-
 
 
 class SpecURI(Nested):
-    # todo: improve cache location
-
     def _deserialize(self, value, attr, data, **kwargs):
         uri = urlparse(value)
 
@@ -30,14 +21,7 @@ class SpecURI(Nested):
         if uri.query:
             raise PyBioValidationException(f"Invalid URI: {uri}. Got URI query: {uri.query}")
 
-        return spec_types.URI(
-            loader=self.schema,
-            scheme=uri.scheme,
-            netloc=uri.netloc,
-            path=uri.path
-        )
-
-        # TODO: Remove stuff
+        return spec_types.SpecURI(spec_schema=self.schema, scheme=uri.scheme, netloc=uri.netloc, path=uri.path)
 
 
 class URI(Str):

--- a/pybio/spec/fields.py
+++ b/pybio/spec/fields.py
@@ -7,7 +7,7 @@ import typing
 from marshmallow.fields import Str, Nested, List, Dict, Integer, Float, Tuple, ValidationError  # noqa
 
 from pybio.spec.exceptions import PyBioValidationException
-from pybio.spec import spec_types
+from pybio.spec import node
 
 
 class SpecURI(Nested):
@@ -21,7 +21,7 @@ class SpecURI(Nested):
         if uri.query:
             raise PyBioValidationException(f"Invalid URI: {uri}. Got URI query: {uri.query}")
 
-        return spec_types.SpecURI(spec_schema=self.schema, scheme=uri.scheme, netloc=uri.netloc, path=uri.path)
+        return node.SpecURI(spec_schema=self.schema, scheme=uri.scheme, netloc=uri.netloc, path=uri.path)
 
 
 class URI(Str):
@@ -59,7 +59,7 @@ class ImportableSource(Str):
 
             module_name = source_str[:last_dot_idx]
             object_name = source_str[last_dot_idx + 1 :]
-            return spec_types.Importable.Module(module_name, object_name)
+            return node.ImportableFromModule(callable_name=object_name, module_name=module_name)
 
         elif self._is_filepath(source_str):
             if source_str.startswith("/"):
@@ -74,7 +74,7 @@ class ImportableSource(Str):
             spec_dir = pathlib.Path(self.context.get("spec_path", ".")).parent
             abs_path = spec_dir / pathlib.Path(module_path)
 
-            return spec_types.Importable.Path(module_path, object_name)
+            return node.ImportableFromPath(callable_name=object_name, filepath=module_path)
 
 
 class Axes(Str):
@@ -92,7 +92,7 @@ class Dependencies(URI):
 
 
 class Tensors(Nested):
-    def __init__(self, *args, valid_magic_values: typing.List[spec_types.MagicTensorsValue], **kwargs):
+    def __init__(self, *args, valid_magic_values: typing.List[node.MagicTensorsValue], **kwargs):
         super().__init__(*args, **kwargs)
         self.valid_magic_values = valid_magic_values
 
@@ -105,7 +105,7 @@ class Tensors(Nested):
     ):
         if isinstance(value, str):
             try:
-                value = spec_types.MagicTensorsValue(value)
+                value = node.MagicTensorsValue(value)
             except ValueError as e:
                 raise PyBioValidationException(str(e)) from e
 
@@ -125,7 +125,7 @@ class Tensors(Nested):
 
 
 class Shape(Nested):
-    def __init__(self, *args, valid_magic_values: typing.List[spec_types.MagicShapeValue], **kwargs):
+    def __init__(self, *args, valid_magic_values: typing.List[node.MagicShapeValue], **kwargs):
         super().__init__(*args, **kwargs)
         self.valid_magic_values = valid_magic_values
 
@@ -138,7 +138,7 @@ class Shape(Nested):
     ):
         if isinstance(value, str):
             try:
-                value = spec_types.MagicShapeValue(value)
+                value = node.MagicShapeValue(value)
             except ValueError as e:
                 raise PyBioValidationException(str(e)) from e
 

--- a/pybio/spec/node.py
+++ b/pybio/spec/node.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import List, Optional, Any, Dict, NewType, Tuple, Union, Type, NamedTuple
 
 
+@dataclass
 class Node:
     pass
 
@@ -21,20 +22,29 @@ class MagicShapeValue(Enum):
     dynamic = "dynamic"
 
 
-class Importable:
-    @dataclass
-    class Path(Node):
-        filepath: str
-        callable_name: str
+@dataclass
+class Importable(Node):
+    callable_name: str
 
 
-    @dataclass
-    class Module(Node):
-        module_name: str
-        callable_name: str
+@dataclass
+class ImportableFromPath(Importable):
+    filepath: str
 
 
-Source = Union[Importable.Path, Importable.Module]
+@dataclass
+class ImportableFromModule(Importable):
+    module_name: str
+
+
+Source = Union[ImportableFromModule, ImportableFromPath]
+
+
+@dataclass
+class WithSource:
+    source: Source
+    required_kwargs: List[str]
+    optional_kwargs: Dict[str, Any]
 
 # Types for non-nested fields
 Axes = NewType("Axes", str)
@@ -49,7 +59,7 @@ class CiteEntry(Node):
 
 
 @dataclass
-class MinimalYAML(Node):
+class BaseSpec(Node, WithSource):
     name: str
     format_version: str
     description: str
@@ -60,9 +70,6 @@ class MinimalYAML(Node):
 
     language: str
     framework: Optional[str]
-    source: Source
-    required_kwargs: List[str]
-    optional_kwargs: Dict[str, Any]
 
     test_input: Optional[Path]
     test_output: Optional[Path]
@@ -108,29 +115,29 @@ class OutputArray(Array):
 
 
 @dataclass
-class WithInputs(Node):
+class WithInputs:
     inputs: Union[MagicTensorsValue, List[InputArray]]
 
 
 @dataclass
-class WithOutputs(Node):
+class WithOutputs:
     outputs: Union[MagicTensorsValue, List[OutputArray]]
 
 
 @dataclass
-class Transformation(MinimalYAML, WithInputs, WithOutputs):
-    dependencies: Dependencies
-
-
-@dataclass
-class BaseSpec(Node):
-    spec: MinimalYAML
+class SpecWithKwargs(Node):
+    spec: BaseSpec
     kwargs: Dict[str, Any]
 
 
 @dataclass
-class TransformationSpec(BaseSpec):
-    spec: Transformation
+class TransformationSpec(BaseSpec, WithInputs, WithOutputs):
+    dependencies: Dependencies
+
+
+@dataclass
+class Transformation(SpecWithKwargs):
+    spec: TransformationSpec
 
 
 @dataclass
@@ -143,66 +150,61 @@ class Weights(Node):
 class Prediction(Node):
     weights: Weights
     dependencies: Optional[Dependencies]
-    preprocess: Optional[List[TransformationSpec]]
-    postprocess: Optional[List[TransformationSpec]]
+    preprocess: Optional[List[Transformation]]
+    postprocess: Optional[List[Transformation]]
 
 
 @dataclass
-class Reader(MinimalYAML, WithOutputs):
+class ReaderSpec(BaseSpec, WithOutputs):
     dependencies: Optional[Dependencies]
 
 
 @dataclass
-class ReaderSpec(BaseSpec):
-    spec: Reader
+class Reader(SpecWithKwargs):
+    spec: ReaderSpec
 
 
 @dataclass
-class Sampler(MinimalYAML, WithOutputs):
+class SamplerSpec(BaseSpec, WithOutputs):
     dependencies: Optional[Dependencies]
 
 
 @dataclass
-class SamplerSpec(BaseSpec):
-    spec = Sampler
+class Sampler(SpecWithKwargs):
+    spec = SamplerSpec
 
 
 @dataclass
-class Optimizer(Node):
-    source: Source
-    required_kwargs: List[str]
-    optional_kwargs: Dict[str, Any]
-
+class Optimizer(Node, WithSource):
+    pass
 
 @dataclass
 class Setup(Node):
-    reader: ReaderSpec
-    sampler: SamplerSpec
-    preprocess: List[TransformationSpec]
-    postprocess: List[TransformationSpec]
-    losses: List[TransformationSpec]
+    reader: Reader
+    sampler: Sampler
+    preprocess: List[Transformation]
+    postprocess: List[Transformation]
+    losses: List[Transformation]
     optimizer: Optimizer
 
 
 @dataclass
-class Training(Node):
+class Training(Node, WithSource):
     setup: Setup
-    source: Source
-    required_kwargs: List[str]
-    optional_kwargs: Dict[str, Any]
     dependencies: Dependencies
     description: Optional[str]
 
 
 @dataclass
-class Model(MinimalYAML, WithInputs, WithOutputs):
+class ModelSpec(BaseSpec, WithInputs, WithOutputs):
     prediction: Prediction
     training: Optional[Training]
 
 
 @dataclass
-class ModelSpec(BaseSpec):
-    spec: Model
+class Model(SpecWithKwargs):
+    spec: ModelSpec
+
 
 @dataclass
 class URI:
@@ -210,10 +212,12 @@ class URI:
     netloc: str
     path: str
 
+
 @dataclass
 class SpecURI(URI):
-    spec_schema: "pybio.spec.schema.MinimalYAML"
+    spec_schema: "pybio.spec.schema.BaseSpec"
+
 
 @dataclass
 class DataURI(URI):
-    spec_schema: "pybio.spec.schema.MinimalYAML"
+    spec_schema: "pybio.spec.schema.BaseSpec"

--- a/pybio/spec/spec_types.py
+++ b/pybio/spec/spec_types.py
@@ -1,3 +1,5 @@
+import pybio
+
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -202,10 +204,16 @@ class Model(MinimalYAML, WithInputs, WithOutputs):
 class ModelSpec(BaseSpec):
     spec: Model
 
-
 @dataclass
 class URI:
-    loader: Type
     scheme: str
     netloc: str
     path: str
+
+@dataclass
+class SpecURI(URI):
+    spec_schema: "pybio.spec.schema.MinimalYAML"
+
+@dataclass
+class DataURI(URI):
+    spec_schema: "pybio.spec.schema.MinimalYAML"

--- a/pybio/spec/utils.py
+++ b/pybio/spec/utils.py
@@ -1,14 +1,14 @@
 import importlib
 import pathlib
+import subprocess
+
 import yaml
-import typing
-import contextlib
 from dataclasses import fields
 from typing import Any, Dict, Optional, Union
 from . import spec_types
 from . import schema
-
-from .spec_types import ModelSpec, TransformationSpec, ReaderSpec, SamplerSpec, Importable, Node
+from .exceptions import PyBioValidationException, InvalidDoiException
+from .spec_types import Importable, Node
 from urllib.parse import ParseResult
 
 
@@ -19,7 +19,7 @@ def iter_fields(node: Node):
 
 class NodeVisitor:
     def visit(self, node: Any) -> None:
-        method = 'visit_' + node.__class__.__name__
+        method = "visit_" + node.__class__.__name__
 
         visitor = getattr(self, method, self.generic_visit)
 
@@ -63,7 +63,7 @@ def get_instance(spec, **kwargs) -> Any:
     return cls(**joined_kwargs)
 
 
-def train(model: ModelSpec, kwargs: Dict[str, Any] = None) -> Any:
+def train(model: spec_types.ModelSpec, kwargs: Dict[str, Any] = None) -> Any:
     if kwargs is None:
         kwargs = {}
 
@@ -79,66 +79,40 @@ def train(model: ModelSpec, kwargs: Dict[str, Any] = None) -> Any:
     return train_cls(**complete_kwargs)
 
 
-def resolve_local_path(path_str: str, parent_path: Optional[str] = None) -> pathlib.Path:
-    local_path = pathlib.Path(path_str)
-    if local_path.is_absolute():
-        return local_path.resolve()
-    elif parent_path:
-        so_far = context["spec_path"]
-        return (so_far[-1].parent / local_path).resolve()
-    else:
-        return local_path.absolute().resolve()
+def resolve_uri(uri_node: spec_types.URI, cache_path: pathlib.Path, root_path: Optional[pathlib.Path] = None) -> pathlib.Path:
+    if (
+        uri_node.scheme == "" or len(uri_node.scheme) == 1
+    ):  # Guess that scheme is not a scheme, but a windows path drive letter instead for uri.scheme == 1
+        if uri_node.netloc:
+            raise PyBioValidationException(f"Invalid Path/URI: {uri_node}")
 
-
-def resolve_uri(uri, parent_path=None):
-    if uri.scheme == "" or len(uri.scheme) == 1:  # Guess that scheme is not a scheme, but a windows path drive letter instead for uri.scheme == 1
-        if uri.netloc:
-            raise PyBioValidationException(f"Invalid Path/URI: {uri}")
-        spec_path = resolve_local_path(value, self.context)
-    elif uri.scheme == "file":
+        if root_path is None:
+            local_path = pathlib.Path(uri_node.path)
+        else:
+            local_path = root_path / uri_node.path
+    elif uri_node.scheme == "file":
         raise NotImplementedError
         # things to keep in mind when implementing this:
         # - problems with absolute paths on windows:
         #   >>> assert Path(urlparse(WindowsPath().absolute().as_uri()).path).exists() fails
         # - relative paths are invalid URIs
-    elif uri.netloc == "github.com":
-        orga, repo_name, blob, commit_id, *in_repo_path = uri.path.strip("/").split("/")
+    elif uri_node.netloc == "github.com":
+        orga, repo_name, blob, commit_id, *in_repo_path = uri_node.path.strip("/").split("/")
         in_repo_path = "/".join(in_repo_path)
-        cached_repo_path = self.cache_path / orga / repo_name / commit_id
-        spec_path = cached_repo_path / in_repo_path
-        if not spec_path.exists():
+        cached_repo_path = cache_path / orga / repo_name / commit_id
+        local_path = cached_repo_path / in_repo_path
+        if not local_path.exists():
             cached_repo_path = cached_repo_path.resolve().as_posix()
             subprocess.call(
-                ["git", "clone", f"{uri.scheme}://{uri.netloc}/{orga}/{repo_name}.git", cached_repo_path]
+                ["git", "clone", f"{uri_node.scheme}://{uri_node.netloc}/{orga}/{repo_name}.git", cached_repo_path]
             )
             # -C <working_dir> available in git 1.8.5+
             # https://github.com/git/git/blob/5fd09df3937f54c5cfda4f1087f5d99433cce527/Documentation/RelNotes/1.8.5.txt#L115-L116
             subprocess.call(["git", "-C", cached_repo_path, "checkout", "--force", commit_id])
     else:
-        raise ValueError(f"Unknown uri scheme {uri.scheme}")
+        raise ValueError(f"Unknown uri scheme {uri_node.scheme}")
 
-    if "spec_path" in self.context:
-        self.context["spec_path"].append(spec_path)
-    else:
-        self.context["spec_path"] = [spec_path]
-
-    with spec_path.open() as f:
-        value_data = yaml.safe_load(f)
-
-    loaded_spec =  super()._deserialize(value_data, attr, data, **kwargs)
-    self.context["spec_path"].pop()
-    return loaded_spec
-
-
-@contextlib.contextmanager
-def modified_sys_path(path: typing.Union[str, pathlib.Path]):
-    # FIXME: Probably all specs containing implementation in same folder should use common prefix for this
-    # to avoid namespace pollution e.g. spec_root.unet2d.UNet2D
-    # or with something like ./unet2d.py::UNet2D
-    sys.path.insert(0, str(path))
-    yield
-    del sys.path[0]
-
+    return local_path
 
 def resolve_doi(uri: ParseResult) -> ParseResult:
     if uri.scheme.lower() != "doi" and not uri.netloc.endswith("doi.org"):
@@ -160,22 +134,22 @@ def resolve_doi(uri: ParseResult) -> ParseResult:
 
 
 class URITransformer(NodeTransformer):
-    def __init__(self, root_path=None):
+    def __init__(self, root_path: pathlib.Path, cache_path: pathlib.Path):
         self.root_path = root_path
+        self.cache_path = cache_path
 
-    def visit_URI(self, node):
-        path = node.path
+    def visit_SpecURI(self, node: spec_types.SpecURI):
+        local_path = resolve_uri(node, root_path=self.root_path, cache_path=self.cache_path)
+        with local_path.open() as f:
+            data = yaml.safe_load(f)
 
-        if self.root_path:
-            path = pathlib.Path(self.root_path) / pathlib.Path(node.path)
+        return self.Transform(node.spec_schema.load(data))
 
-        with open(path) as f:
-            res = yaml.safe_load(f)
-        return self.Transform(node.loader.load(res))
-
+    def visit_URI(self, node: spec_types.URI):
+        raise NotImplementedError
 
 def load_spec(
-    uri: str, kwargs: Dict[str, Any] = None
+    uri: str, kwargs: Dict[str, Any] = None, cache_path: pathlib.Path = pathlib.Path("./cache")
 ) -> Union[spec_types.ModelSpec, spec_types.TransformationSpec, spec_types.ReaderSpec, spec_types.SamplerSpec]:
 
     data = {"spec": uri, "kwargs": kwargs or {}}
@@ -193,8 +167,8 @@ def load_spec(
     else:
         raise ValueError(f"Invalid spec suffix: {spec_suffix}")
 
-    transformer = URITransformer()
-    transformer.visit(tree)
-    transformer = URITransformer(pathlib.Path(uri).parent)
+    local_spec_path = resolve_uri(uri_node=tree.spec, cache_path=cache_path)
+
+    transformer = URITransformer(root_path=local_spec_path.parent, cache_path=cache_path)
     transformer.visit(tree)
     return tree

--- a/specs/models/sklearnbased/RandomForestClassifierBroadNucleusDataBinarized.model.yaml
+++ b/specs/models/sklearnbased/RandomForestClassifierBroadNucleusDataBinarized.model.yaml
@@ -58,7 +58,7 @@ training:
             kwargs: {sample_dimensions: [0, 0]}
 
     source: pybio.core.training.classic_fit.classic_fit
-    required_kwargs: [model_spec]
+    required_kwargs: [pybio_model]
     optional_kwargs: {start: 0, batch_size: 1}
     # enable different ways of specifying the dependencies.
     # this would hold all training dependencies, e.g. as a frozen conda environment

--- a/tests/test_pybio/test_core/test_manifest.py
+++ b/tests/test_pybio/test_core/test_manifest.py
@@ -3,7 +3,7 @@ import yaml
 
 from pathlib import Path
 
-from pybio.spec import load_spec
+from pybio.spec import load_spec_and_kwargs
 
 MANIFEST_PATH = Path(__file__).parent.parent.parent.parent / "manifest.yaml"
 
@@ -42,6 +42,6 @@ def test_load_specs_from_manifest(category, spec_path, required_kwargs):
     spec_path = MANIFEST_PATH.parent / spec_path
     assert spec_path.exists()
 
-    loaded_spec = load_spec(spec_path.as_posix(), kwargs=kwargs)
+    loaded_spec = load_spec_and_kwargs(spec_path.as_posix(), kwargs=kwargs)
 
     assert loaded_spec

--- a/tests/test_pybio/test_core/test_models/test_from_sklearn.py
+++ b/tests/test_pybio/test_core/test_models/test_from_sklearn.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import numpy
 
-from pybio.spec import load_spec, utils
+from pybio.spec import utils, load_model
 
 
 def test_RandomForestClassifierBroadNucleusDataBinarized():
@@ -10,8 +10,8 @@ def test_RandomForestClassifierBroadNucleusDataBinarized():
         Path(__file__).parent
         / "../../../../specs/models/sklearnbased/RandomForestClassifierBroadNucleusDataBinarized.model.yaml"
     )
-    loaded_spec = load_spec(spec_path.as_posix(), kwargs={"c_indices": [None]})
-    model = utils.train(loaded_spec)
+    pybio_model = load_model(spec_path.as_posix(), kwargs={"c_indices": [None]})
+    model = utils.train(pybio_model)
 
     ipt = [numpy.arange(24).reshape((2, 3, 4))]
     out = model(ipt)

--- a/tests/test_pybio/test_spec/test_load_spec.py
+++ b/tests/test_pybio/test_spec/test_load_spec.py
@@ -1,17 +1,17 @@
 import pytest
 
-from pybio.spec import load_spec
+from pybio.spec import load_spec_and_kwargs
 
 
 def test_load_non_existing_spec():
     spec_path = "some/none/existing/path/to/spec.model.yaml"
 
     with pytest.raises(FileNotFoundError):
-        load_spec(spec_path)
+        load_spec_and_kwargs(spec_path)
 
 
 def test_load_non_valid_spec_name():
     spec_path = "some/none/existing/path/to/spec.not_valid.yaml"
 
     with pytest.raises(ValueError):
-        load_spec(spec_path)
+        load_spec_and_kwargs(spec_path)

--- a/tests/test_pybio/test_spec/test_util.py
+++ b/tests/test_pybio/test_spec/test_util.py
@@ -1,13 +1,13 @@
 import pytest
 
 from dataclasses import dataclass
-from pybio.spec import utils, spec_types, fields, schema
+from pybio.spec import utils, node, fields, schema
 from typing import Any
 from marshmallow import post_load
 
 
 @dataclass
-class MyNode(spec_types.Node):
+class MyNode(node.Node):
     field_a: str
     field_b: int
 
@@ -24,7 +24,7 @@ class Content:
 
 class TestNodeVisitor:
     @dataclass
-    class Tree(spec_types.Node):
+    class Tree(node.Node):
         left: Any
         right: Any
 
@@ -55,9 +55,9 @@ class TestNodeVisitor:
 
 
 @dataclass
-class MySpec(spec_types.Node):
-    spec_uri_a: spec_types.SpecURI
-    spec_uri_b: spec_types.SpecURI
+class MySpec(node.Node):
+    spec_uri_a: node.SpecURI
+    spec_uri_b: node.SpecURI
 
 
 class SubSpec(schema.Schema):


### PR DESCRIPTION
To enable the `URITransformer` to descend into referenced specs I added `SpecURI`. 
While doing so I appreciated @m-novikov 's addition of the `Node` class and noticed some older confusing variable names. 
Here I propose the following name changes (all changes in backend only):
Fundamental name changes:
- module `pybio.spec.spec_types` -> `pybio.spec.node` (it specifies all Nodes)
- **BaseSpec**(Node) -> **SpecWithKwargs**(Node)
- **ModelSpec**(BaseSpec) -> **Model**(SpecWithKwargs) (also for Transformation, Reader, Sampler)
- **Model**(MinimalYAML, WithInputs, WithOutputs) -> **ModelSpec**(BaseSpec, WithInputs, WithOutputs) (also for Transformation, Reader, Sampler)
-  MinimalYAML(Node) -> BaseSpec(Node, WithSource)

Especially the **highlighted** changes are motivated by the following train of thought:
A spec like <name>.transformation.yaml now is represented by the class `TransformationSpec(BaseSpec)`. If used somewhere else (e.g. in a <name>.model.yaml) a `transformation` is a pair of `spec` and `kwargs`, thus represented by `Transformation(SpecWithKwargs)`.
Model specs are somewhat special, as their checkpoints are generally only valid for the default values of optional kwargs, as a `ModelSpec` instance is equivalent to a `Model'='ModelSpecWithKwargs' without any given kwargs. Generally overwriting any optional kwargs might break something. I still think we should keep this pattern (at least for the forseeable future). If we want to emphasize the danger of loading models with 'new' kwargs, we might consider to remove `kwargs` from the `load_model(spec_uri: str, **kwargs)` function signature.

Derived changes:
- `model_spec` -> `pybio_model`

side note: Furthermore I changed the `Importable`s to inherit from `Importable` instead of being member classes to allow for correct type checking (fixes type hint in https://github.com/bioimage-io/python-bioimage-io/blob/c355c4e82dc6b2c0f3394853d04f72e5ffb1bbdc/pybio/spec/utils.py#L48):
- `spec_types.Importable.Module` -> `node.ImportableFromModule(Importable)`
- `spec_types.Importable.Path` -> `node.ImportableFromPath(Importable)`
