### PR TITLE
drop model kwargs in json schema

### DIFF
--- a/json_specs/model_spec.json
+++ b/json_specs/model_spec.json
@@ -169,10 +169,6 @@
                     "title": "name",
                     "type": "string"
                 },
-                "optional_kwargs": {
-                    "title": "optional_kwargs",
-                    "type": "object"
-                },
                 "outputs": {
                     "items": {
                         "$ref": "#/definitions/OutputArray",
@@ -186,14 +182,6 @@
                 "prediction": {
                     "$ref": "#/definitions/Prediction",
                     "type": "object"
-                },
-                "required_kwargs": {
-                    "items": {
-                        "title": "required_kwargs",
-                        "type": "string"
-                    },
-                    "title": "required_kwargs",
-                    "type": "array"
                 },
                 "source": {
                     "title": "source",

--- a/scripts/generate_json_specs.py
+++ b/scripts/generate_json_specs.py
@@ -10,4 +10,8 @@ JSON_SPEC_PATH = Path(__file__).parent / "../json_specs"
 model_schema = ModelSpec()
 
 with (JSON_SPEC_PATH / "model_spec.json").open("w") as f:
-    json.dump(JSONSchema().dump(model_schema), f, indent=4, sort_keys=True)
+    json_schema = JSONSchema().dump(model_schema)
+    # drop kwargs for now as discussed in https://github.com/bioimage-io/python-bioimage-io/issues/27
+    json_schema["definitions"]["ModelSpec"]["properties"].pop("optional_kwargs")
+    json_schema["definitions"]["ModelSpec"]["properties"].pop("required_kwargs")
+    json.dump(json_schema, f, indent=4, sort_keys=True)


### PR DESCRIPTION
model key word arguments were not part of the spec and only implemented in the Marshmallow schema. 
This PR removes them from the generated JSON schema, as discussed in #27 
If we want to add model key word arguments to the model specification can be discussed in #31 
