### PR TITLE
Update json schema export

### DIFF
--- a/json_specs/generated_model_spec_0.3.0.json
+++ b/json_specs/generated_model_spec_0.3.0.json
@@ -157,7 +157,10 @@
                 },
                 "git_repo": {
                     "title": "git_repo",
-                    "type": "string"
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
                 "inputs": {
                     "items": {
@@ -200,6 +203,10 @@
                         "array",
                         "null"
                     ]
+                },
+                "run_mode": {
+                    "$ref": "#/definitions/RunMode",
+                    "type": "object"
                 },
                 "sample_inputs": {
                     "items": {
@@ -413,6 +420,24 @@
             ],
             "type": "object"
         },
+        "RunMode": {
+            "additionalProperties": false,
+            "properties": {
+                "kwargs": {
+                    "additionalProperties": {},
+                    "title": "kwargs",
+                    "type": "object"
+                },
+                "name": {
+                    "title": "name",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "type": "object"
+        },
         "WeightsEntry": {
             "additionalProperties": false,
             "properties": {
@@ -429,6 +454,21 @@
                     "title": "authors",
                     "type": "array"
                 },
+                "opset_version": {
+                    "format": "decimal",
+                    "title": "opset_version",
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "parent": {
+                    "title": "parent",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "sha256": {
                     "maxLength": 64,
                     "minLength": 64,
@@ -440,6 +480,9 @@
                 },
                 "source": {
                     "title": "source",
+                    "type": "string"
+                },
+                "tensorflow_version": {
                     "type": "string"
                 }
             },

--- a/pybio/spec/fields.py
+++ b/pybio/spec/fields.py
@@ -38,6 +38,9 @@ class StrictVersion(marshmallow_fields.Field):
     def _serialize(self, value: typing.Any, attr: str, obj: typing.Any, **kwargs):
         return str(value)
 
+    def _jsonschema_type_mapping(self):
+        return {"type": "string"}
+
 
 class DateTime(marshmallow_fields.DateTime):
     """

--- a/scripts/generate_json_specs.py
+++ b/scripts/generate_json_specs.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from marshmallow_jsonschema import JSONSchema  # todo: add marshmallow_jsonschema to dependencies
 
+import pybio.spec
 from pybio.spec.schema import Model
 
 JSON_SPEC_PATH = Path(__file__).parent / "../json_specs"
@@ -11,7 +12,7 @@ JSON_SPEC_PATH = Path(__file__).parent / "../json_specs"
 def generate_json_model_spec():
     model_schema = Model()
 
-    with (JSON_SPEC_PATH / "model_spec.json").open("w") as f:
+    with (JSON_SPEC_PATH / f"generated_model_spec_{pybio.spec.__version__}.json").open("w") as f:
         json_schema = JSONSchema().dump(model_schema)
         json.dump(json_schema, f, indent=4, sort_keys=True)
 


### PR DESCRIPTION
add 'generated' and spec version to the generated json schema spec.
If the json schema keeps being relevant, we might want to consider generating it with a CI instead of generating offline and commiting the generated schema...
Fixes #57 