### PR TITLE
Add tests for prediction pipeline; add keras model adapter

### DIFF
--- a/bioimageio/core/model_test.py
+++ b/bioimageio/core/model_test.py
@@ -36,9 +36,7 @@ def model_test(source: Union[Path, str], weight_format: Optional[str], devices: 
             msg += f" for weight format {weight_format}"
         raise RuntimeError(msg) from e
 
-    pipeline = create_prediction_pipeline(
-        bioimageio_model=model, devices=devices
-    )
+    pipeline = create_prediction_pipeline(bioimageio_model=model, devices=devices)
 
     try:
         inputs = [load_array(inp, inp_spec) for inp, inp_spec in zip(model.test_inputs, model.inputs)]

--- a/bioimageio/core/predict.py
+++ b/bioimageio/core/predict.py
@@ -2,8 +2,6 @@ import argparse
 import sys
 
 import numpy as np
-# FIXME this is too torch specific
-import torch.cuda
 import xarray as xr
 
 from bioimageio.core.prediction_pipeline import create_prediction_pipeline
@@ -14,6 +12,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-m", "--model", help="bioimage model resource (ziped package or rdf.yaml)", required=True)
 parser.add_argument("images", nargs="+", dest="image(s)", help="image(s) to process (.npy)")
 parser.add_argument("-o", "--outputs", nargs="+", dest="output(s)", help="output image(s) (.npy)", required=True)
+parser.add_argument("--devices", nargs="+", help="Devices to run this model", default=None)
 
 
 def main():
@@ -21,7 +20,7 @@ def main():
     model = load_resource_description(args.model)
     assert isinstance(model, Model)
     prediction_pipeline = create_prediction_pipeline(
-        bioimageio_model=model, devices=["cuda" if torch.cuda.is_available() else "cpu"]
+        bioimageio_model=model, devices=args.devices
     )
 
     if len(args.images) != len(model.inputs):

--- a/bioimageio/core/predict.py
+++ b/bioimageio/core/predict.py
@@ -19,9 +19,7 @@ def main():
     args = parser.parse_args()
     model = load_resource_description(args.model)
     assert isinstance(model, Model)
-    prediction_pipeline = create_prediction_pipeline(
-        bioimageio_model=model, devices=args.devices
-    )
+    prediction_pipeline = create_prediction_pipeline(bioimageio_model=model, devices=args.devices)
 
     if len(args.images) != len(model.inputs):
         raise ValueError(f"Expected {len(model.inputs)} input images, not {len(args.images)}")
@@ -30,8 +28,9 @@ def main():
         raise ValueError(f"Expected {len(model.outputs)} output images, not {len(args.outputs)}")
 
     input_tensors = [np.load(ipt) for ipt in args.images]
-    tagged_data = [xr.DataArray(ipt_tensor, dims=tuple(ipt.axes))
-                   for ipt_tensor, ipt in zip(input_tensors, model.inputs)]
+    tagged_data = [
+        xr.DataArray(ipt_tensor, dims=tuple(ipt.axes)) for ipt_tensor, ipt in zip(input_tensors, model.inputs)
+    ]
     if len(tagged_data) > 1:
         raise NotImplementedError(len(tagged_data))
 

--- a/bioimageio/core/predict.py
+++ b/bioimageio/core/predict.py
@@ -2,6 +2,7 @@ import argparse
 import sys
 
 import numpy as np
+# FIXME this is too torch specific
 import torch.cuda
 import xarray as xr
 
@@ -30,7 +31,8 @@ def main():
         raise ValueError(f"Expected {len(model.outputs)} output images, not {len(args.outputs)}")
 
     input_tensors = [np.load(ipt) for ipt in args.images]
-    tagged_data = [xr.DataArray(ipt_tensor, dims=tuple(ipt.axes)) for ipt_tensor, ipt in zip(input_tensors, model.inputs)]
+    tagged_data = [xr.DataArray(ipt_tensor, dims=tuple(ipt.axes))
+                   for ipt_tensor, ipt in zip(input_tensors, model.inputs)]
     if len(tagged_data) > 1:
         raise NotImplementedError(len(tagged_data))
 

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_model_adapter.py
@@ -15,7 +15,7 @@ class ModelAdapter(abc.ABC):
     """
 
     @abc.abstractmethod
-    def __init__(self, *, bioimageio_model: nodes.Model, devices=List[str]):
+    def __init__(self, *, bioimageio_model: nodes.Model, devices=Optional[List[str]]):
         ...
 
     # todo: separate preprocessing/actual forward/postprocessing
@@ -37,7 +37,7 @@ def get_weight_formats() -> List[str]:
 
 
 def create_model_adapter(
-    *, bioimageio_model: nodes.Model, devices=List[str], weight_format: Optional[str] = None
+    *, bioimageio_model: nodes.Model, devices=Optional[List[str]], weight_format: Optional[str] = None
 ) -> ModelAdapter:
     """
     Creates model adapter based on the passed spec

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_model_adapter.py
@@ -1,12 +1,12 @@
 import abc
-from typing import Callable, List, Optional, Type
+from typing import List, Optional, Type
 
 import xarray as xr
 from bioimageio.spec.model import nodes
 
 #: Known weigh types in order of priority
 #: First match wins
-_WEIGHT_FORMATS = ["pytorch_state_dict", "tensorflow_saved_model_bundle", "pytorch_script", "onnx"]
+_WEIGHT_FORMATS = ["pytorch_state_dict", "tensorflow_saved_model_bundle", "pytorch_script", "onnx", "keras_hdf5"]
 
 
 class ModelAdapter(abc.ABC):
@@ -86,6 +86,11 @@ def _get_model_adapter(weight_format: str) -> Type[ModelAdapter]:
         from ._torchscript_model_adapter import TorchscriptModelAdapter
 
         return TorchscriptModelAdapter
+
+    elif weight_format == "keras_hdf5":
+        from ._tensorflow_model_adapter import KerasModelAdapter
+
+        return KerasModelAdapter
 
     else:
         raise ValueError(f"Weight format {weight_format} is not supported.")

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_onnx_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_onnx_model_adapter.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from typing import List, Optional
 
 import onnxruntime as rt
@@ -32,6 +33,8 @@ class ONNXModelAdapter(ModelAdapter):
         self._input_name = onnx_inputs[0].name
         # TODO onnx device management
         self.devices = []
+        if devices is not None:
+            warnings.warn(f"Device management is not implemented for onnx yet, ignoring the devices {devices}")
 
     def forward(self, input: xr.DataArray) -> xr.DataArray:
         result = self._session.run(None, {self._input_name: input.data})[0]

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_onnx_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_onnx_model_adapter.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List
+from typing import List, Optional
 
 import onnxruntime as rt
 import xarray as xr
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 class ONNXModelAdapter(ModelAdapter):
-    def __init__(self, *, bioimageio_model: nodes.Model, devices=List[str]):
+    def __init__(self, *, bioimageio_model: nodes.Model, devices: Optional[List[str]] = None):
         spec = bioimageio_model
         self.name = spec.name
 
@@ -30,6 +30,7 @@ class ONNXModelAdapter(ModelAdapter):
         onnx_inputs = self._session.get_inputs()
         assert len(onnx_inputs) == 1, f"expected onnx model to have one input got {len(onnx_inputs)}"
         self._input_name = onnx_inputs[0].name
+        # TODO onnx device management
         self.devices = []
 
     def forward(self, input: xr.DataArray) -> xr.DataArray:

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_tensorflow_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_tensorflow_model_adapter.py
@@ -4,7 +4,6 @@ import numpy as np
 import tensorflow as tf
 import xarray as xr
 
-from bioimageio.core.utils import get_nn_instance
 from bioimageio.spec.model import nodes
 from ._model_adapter import ModelAdapter
 
@@ -19,11 +18,9 @@ class TensorflowModelAdapterBase(ModelAdapter):
         # FIXME: TF probably uses different axis names
         self._internal_output_axes = _output.axes
 
-        # FIXME why do we call get_nn_instance here?
-        self.model = get_nn_instance(bioimageio_model)
         self.devices = []
-        tf_model = tf.keras.models.load_model(spec.weights[weight_format].source)
-        self.model.set_model(tf_model)
+        weight_file = spec.weights[weight_format].source
+        self.model = tf.keras.models.load_model(weight_file)
 
     def forward(self, input_tensor: xr.DataArray) -> xr.DataArray:
         tf_tensor = tf.convert_to_tensor(input_tensor.data)
@@ -37,12 +34,12 @@ class TensorflowModelAdapterBase(ModelAdapter):
 
 
 class TensorflowModelAdapter(TensorflowModelAdapterBase):
-    def __init__(self, *, bioimageio_model: nodes.Model, weight_format: str, devices=List[str]):
+    def __init__(self, *, bioimageio_model: nodes.Model, devices=List[str]):
         weight_format = "tensorflow_saved_model_bundle"
         super().__init__(bioimageio_model=bioimageio_model, weight_format=weight_format, devices=devices)
 
 
 class KerasModelAdapter(TensorflowModelAdapterBase):
-    def __init__(self, *, bioimageio_model: nodes.Model, weight_format: str, devices=List[str]):
+    def __init__(self, *, bioimageio_model: nodes.Model, devices=List[str]):
         weight_format = "keras_hdf5"
         super().__init__(bioimageio_model=bioimageio_model, weight_format=weight_format, devices=devices)

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_tensorflow_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_tensorflow_model_adapter.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 import numpy as np
 import tensorflow as tf
@@ -9,7 +9,7 @@ from ._model_adapter import ModelAdapter
 
 
 class TensorflowModelAdapterBase(ModelAdapter):
-    def __init__(self, *, bioimageio_model: nodes.Model, weight_format: str, devices=List[str]):
+    def __init__(self, *, bioimageio_model: nodes.Model, weight_format: str, devices: Optional[List[str]] = None):
         spec = bioimageio_model
         self.name = spec.name
 
@@ -18,6 +18,7 @@ class TensorflowModelAdapterBase(ModelAdapter):
         # FIXME: TF probably uses different axis names
         self._internal_output_axes = _output.axes
 
+        # TODO tf device management
         self.devices = []
         weight_file = spec.weights[weight_format].source
         self.model = tf.keras.models.load_model(weight_file)

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_tensorflow_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_tensorflow_model_adapter.py
@@ -9,8 +9,8 @@ from bioimageio.spec.model import nodes
 from ._model_adapter import ModelAdapter
 
 
-class TensorflowModelAdapter(ModelAdapter):
-    def __init__(self, *, bioimageio_model: nodes.Model, devices=List[str]):
+class TensorflowModelAdapterBase(ModelAdapter):
+    def __init__(self, *, bioimageio_model: nodes.Model, weight_format: str, devices=List[str]):
         spec = bioimageio_model
         self.name = spec.name
 
@@ -19,9 +19,10 @@ class TensorflowModelAdapter(ModelAdapter):
         # FIXME: TF probably uses different axis names
         self._internal_output_axes = _output.axes
 
+        # FIXME why do we call get_nn_instance here?
         self.model = get_nn_instance(bioimageio_model)
         self.devices = []
-        tf_model = tf.keras.models.load_model(spec.weights["tensorflow_saved_model_bundle"].source)
+        tf_model = tf.keras.models.load_model(spec.weights[weight_format].source)
         self.model.set_model(tf_model)
 
     def forward(self, input_tensor: xr.DataArray) -> xr.DataArray:
@@ -33,3 +34,15 @@ class TensorflowModelAdapter(ModelAdapter):
             res = tf.make_ndarray(res)
 
         return xr.DataArray(res, dims=tuple(self._internal_output_axes))
+
+
+class TensorflowModelAdapter(TensorflowModelAdapterBase):
+    def __init__(self, *, bioimageio_model: nodes.Model, weight_format: str, devices=List[str]):
+        weight_format = "tensorflow_saved_model_bundle"
+        super().__init__(bioimageio_model=bioimageio_model, weight_format=weight_format, devices=devices)
+
+
+class KerasModelAdapter(TensorflowModelAdapterBase):
+    def __init__(self, *, bioimageio_model: nodes.Model, weight_format: str, devices=List[str]):
+        weight_format = "keras_hdf5"
+        super().__init__(bioimageio_model=bioimageio_model, weight_format=weight_format, devices=devices)

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_tensorflow_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_tensorflow_model_adapter.py
@@ -1,3 +1,4 @@
+import warnings
 import zipfile
 from typing import List, Optional
 
@@ -28,7 +29,10 @@ class TensorflowModelAdapterBase(ModelAdapter):
         self._internal_output_axes = _output.axes
 
         # TODO tf device management
+        if devices is not None:
+            warnings.warn(f"Device management is not implemented for tensorflow yet, ignoring the devices {devices}")
         self.devices = []
+
         weight_file = self.require_unzipped(spec.weights[weight_format].source)
         self.model = tf.keras.models.load_model(weight_file)
 

--- a/bioimageio/core/prediction_pipeline/_prediction_pipeline.py
+++ b/bioimageio/core/prediction_pipeline/_prediction_pipeline.py
@@ -8,6 +8,7 @@ from marshmallow import missing
 
 from ._model_adapters import ModelAdapter, create_model_adapter
 from ._postprocessing import make_postprocessing
+
 # from ._preprocessing import ADD_BATCH_DIM, make_ensure_dtype_preprocessing
 from ._preprocessing import make_preprocessing
 from ._types import Transform

--- a/bioimageio/core/prediction_pipeline/_prediction_pipeline.py
+++ b/bioimageio/core/prediction_pipeline/_prediction_pipeline.py
@@ -173,7 +173,7 @@ def enforce_min_shape(min_shape, step, axes):
 
 
 def create_prediction_pipeline(
-    *, bioimageio_model: nodes.Model, devices=List[str], weight_format: Optional[str] = None
+    *, bioimageio_model: nodes.Model, devices: Optional[List[str]] = None, weight_format: Optional[str] = None
 ) -> PredictionPipeline:
     """
     Creates prediction pipeline which includes:

--- a/bioimageio/core/weight_converter/torch/onnx.py
+++ b/bioimageio/core/weight_converter/torch/onnx.py
@@ -33,9 +33,6 @@ def convert_weights_to_onnx(
         use_tracing: whether to use tracing or scripting to export the onnx format
         verbose: be verbose during the onnx export
     """
-    if rt is None:
-        raise RuntimeError("Could not find onnxruntime.")
-
     if isinstance(model_spec, (str, Path)):
         root = os.path.split(model_spec)[0]
         model_spec = spec.load_resource_description(Path(model_spec), root_path=root)
@@ -57,7 +54,7 @@ def convert_weights_to_onnx(
         if rt is None:
             msg = "The onnx weights were exported, but onnx rt is not available and weights cannot be checked."
             warnings.warn(msg)
-            return
+            return 1
 
         # check the onnx model
         sess = rt.InferenceSession(str(output_path))  # does not support Path, so need to cast to str

--- a/bioimageio/core/weight_converter/torch/onnx.py
+++ b/bioimageio/core/weight_converter/torch/onnx.py
@@ -22,7 +22,7 @@ def convert_weights_to_onnx(
     output_path: Union[str, Path],
     opset_version: Union[str, None] = 12,
     use_tracing: bool = True,
-    verbose: bool = True
+    verbose: bool = True,
 ):
     """ Convert model weights from format 'pytorch_state_dict' to 'onnx'.
 
@@ -42,7 +42,7 @@ def convert_weights_to_onnx(
 
     with torch.no_grad():
         # load input and expected output data
-        input_data = np.load(model_spec.test_inputs[0]).astype('float32')
+        input_data = np.load(model_spec.test_inputs[0]).astype("float32")
         input_tensor = torch.from_numpy(input_data)
 
         # instantiate and generate the expected output
@@ -50,8 +50,7 @@ def convert_weights_to_onnx(
         expected_output = model(input_tensor).numpy()
 
         if use_tracing:
-            torch.onnx.export(model, input_tensor, output_path, verbose=verbose,
-                              opset_version=opset_version)
+            torch.onnx.export(model, input_tensor, output_path, verbose=verbose, opset_version=opset_version)
         else:
             raise NotImplementedError
 
@@ -83,12 +82,10 @@ def main():
     parser.add_argument("--verbose", "-v", default=1, type=int)
 
     args = parser.parse_args()
-    return convert_weights_to_onnx(os.path.abspath(args.model),
-                                   args.output,
-                                   args.opset_version,
-                                   bool(args.tracing),
-                                   bool(args.verbose))
+    return convert_weights_to_onnx(
+        os.path.abspath(args.model), args.output, args.opset_version, bool(args.tracing), bool(args.verbose)
+    )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/bioimageio/core/weight_converter/torch/torchscript.py
+++ b/bioimageio/core/weight_converter/torch/torchscript.py
@@ -15,7 +15,6 @@ from .utils import load_model
 
 
 def _check_predictions(model, scripted_model, model_spec, input_data):
-
     def _check(expected_output, output):
         try:
             assert_array_almost_equal(expected_output, output, decimal=4)
@@ -50,10 +49,7 @@ def _check_predictions(model, scripted_model, model_spec, input_data):
     # check that input and output agree for decreasing input sizes
     while True:
 
-        slice_ = tuple(
-            slice(None) if st == 0 else slice(step_factor * st, -step_factor * st)
-            for st in half_step
-        )
+        slice_ = tuple(slice(None) if st == 0 else slice(step_factor * st, -step_factor * st) for st in half_step)
         this_input = input_data[slice_]
         this_shape = this_input.shape
         if any(tsh < msh for tsh, msh in zip(this_shape, min_shape)):
@@ -73,9 +69,7 @@ def _check_predictions(model, scripted_model, model_spec, input_data):
 
 
 def convert_weights_to_pytorch_script(
-    model_spec: Union[str, Path, spec.model.raw_nodes.Model],
-    output_path: Union[str, Path],
-    use_tracing: bool = True
+    model_spec: Union[str, Path, spec.model.raw_nodes.Model], output_path: Union[str, Path], use_tracing: bool = True
 ):
     """ Convert model weights from format 'pytorch_state_dict' to 'torchscript'.
     """
@@ -85,7 +79,7 @@ def convert_weights_to_pytorch_script(
 
     with torch.no_grad():
         # load input and expected output data
-        input_data = np.load(model_spec.test_inputs[0]).astype('float32')
+        input_data = np.load(model_spec.test_inputs[0]).astype("float32")
         input_data = torch.from_numpy(input_data)
 
         # instantiate model and get reference output
@@ -112,10 +106,8 @@ def main():
     parser.add_argument("--tracing", "-t", default=1, type=int)
 
     args = parser.parse_args()
-    return convert_weights_to_pytorch_script(os.path.abspath(args.model),
-                                             args.output,
-                                             bool(args.tracing))
+    return convert_weights_to_pytorch_script(os.path.abspath(args.model), args.output, bool(args.tracing))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/bioimageio/core/weight_converter/torch/utils.py
+++ b/bioimageio/core/weight_converter/torch/utils.py
@@ -14,7 +14,7 @@ def get_nn_instance(node, **kwargs):
 # and for each weight format
 def load_model(node):
     model = get_nn_instance(node)
-    state = torch.load(node.weights['pytorch_state_dict'].source)
+    state = torch.load(node.weights["pytorch_state_dict"].source)
     model.load_state_dict(state)
     model.eval()
     return model

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,28 @@ import pytest
 from bioimageio.spec import export_resource_package
 
 
+# set 'skip_<FRAMEWORK>' flags as global pytest variables,
+# to deselect tests that require frameworks not available in current env
+def pytest_configure():
+    try:
+        import tensorflow
+    except ImportError:
+        tensorflow = None
+    pytest.skip_tf = tensorflow is None
+
+    try:
+        import torch
+    except ImportError:
+        torch = None
+    pytest.skip_torch = torch is None
+
+    try:
+        import onnxruntime
+    except ImportError:
+        onnxruntime = None
+    pytest.skip_onnx = onnxruntime is None
+
+
 @pytest.fixture
 def unet2d_nuclei_broad_model():
     url = ("https://raw.githubusercontent.com/bioimage-io/spec-bioimage-io/main/example_specs/"

--- a/tests/prediction_pipeline/test_prediction_pipeline.py
+++ b/tests/prediction_pipeline/test_prediction_pipeline.py
@@ -1,0 +1,49 @@
+import bioimageio.spec as spec
+import numpy as np
+import pytest
+import xarray as xr
+from numpy.testing import assert_array_almost_equal
+
+
+def _test_prediction_pipeline(model_package, weight_format):
+    from bioimageio.core.prediction_pipeline import create_prediction_pipeline
+    bio_model = spec.load_resource_description(model_package)
+    # FIXME devices need to be handled framework independent
+    pp = create_prediction_pipeline(bioimageio_model=bio_model, weight_format=weight_format, devices=["cpu"])
+
+    input_tensors = [np.load(ipt) for ipt in bio_model.test_inputs]
+    assert len(input_tensors) == 1
+    tagged_data = [xr.DataArray(ipt_tensor, dims=tuple(ipt.axes))
+                   for ipt_tensor, ipt in zip(input_tensors, bio_model.inputs)]
+    output = pp.forward(*tagged_data)
+
+    expected_outputs = [np.load(opt) for opt in bio_model.test_outputs]
+    assert len(expected_outputs) == 1
+    expected_output = expected_outputs[0]
+
+    assert_array_almost_equal(output, expected_output, decimal=4)
+
+
+@pytest.mark.skipif(pytest.skip_torch, reason="requires torch")
+def test_prediction_pipeline_torch(unet2d_nuclei_broad_model):
+    _test_prediction_pipeline(unet2d_nuclei_broad_model, "pytorch_state_dict")
+
+
+@pytest.mark.skipif(pytest.skip_torch, reason="requires torch")
+def test_prediction_pipeline_torchscript(unet2d_nuclei_broad_model):
+    _test_prediction_pipeline(unet2d_nuclei_broad_model, "pytorch_script")
+
+
+@pytest.mark.skipif(pytest.skip_onnx, reason="requires onnx")
+def test_prediction_pipeline_onnx(unet2d_nuclei_broad_model):
+    _test_prediction_pipeline(unet2d_nuclei_broad_model, "onnx")
+
+
+@pytest.mark.skipif(pytest.skip_tf, reason="requires tensorflow")
+def test_prediction_pipeline_tensorflow(FruNet_model):
+    _test_prediction_pipeline(FruNet_model, "tensorflow_saved_model_bundle")
+
+
+@pytest.mark.skipif(pytest.skip_tf, reason="requires tensorflow")
+def test_prediction_pipeline_keras(FruNet_model):
+    _test_prediction_pipeline(FruNet_model, "keras_hdf5")

--- a/tests/weight_converter/torch/test_onnx.py
+++ b/tests/weight_converter/torch/test_onnx.py
@@ -1,23 +1,15 @@
 import os
 import pytest
 
-try:
-    import torch
-except ImportError:
-    torch = None
 
-try:
-    import onnxruntime as rt
-except ImportError:
-    rt = None
-
-
-@pytest.mark.skipif(torch is None, reason="requires pytorch")
-@pytest.mark.skipif(rt is None, reason="requires onnx")
+@pytest.mark.skipif(pytest.skip_torch, reason="requires pytorch")
 def test_torchscript_converter(unet2d_nuclei_broad_model, tmp_path):
     from bioimageio.core.weight_converter.torch.onnx import convert_weights_to_onnx
 
     out_path = tmp_path / "weights.onnx"
     convert_weights_to_onnx(unet2d_nuclei_broad_model, out_path)
     assert os.path.exists(out_path)
+
     # TODO check that weights can be loaded and results agree if we have onnx runtime
+    if not pytest.skip_onnx:
+        pass

--- a/tests/weight_converter/torch/test_torchscript.py
+++ b/tests/weight_converter/torch/test_torchscript.py
@@ -1,12 +1,8 @@
 import os
 import pytest
-try:
-    import torch
-except ImportError:
-    torch = None
 
 
-@pytest.mark.skipif(torch is None, reason="requires pytorch")
+@pytest.mark.skipif(pytest.skip_torch, reason="requires pytorch")
 def test_torchscript_converter(unet2d_nuclei_broad_model, tmp_path):
     from bioimageio.core.weight_converter.torch import convert_weights_to_pytorch_script
     out_path = tmp_path / "weights.pt"


### PR DESCRIPTION
I have started to add the keras model adapter (not tested yet) and tests for the prediction pipeline.
One thing I noticed is that the device management in the prediction pipeline seems to be tailored to torch right now.
We should think about more framework agnostic device management.

Also, the test for the torchscript model currently fails with `E           RuntimeError: [enforce fail at inline_container.cc:145] . PytorchStreamReader failed reading zip archive: unsupported multidisk archive   `.
It seems like the torchscript weights in the example model are corrupted....