### PR TITLE
Add support for multiple tensor input/output

### DIFF
--- a/bioimageio/core/prediction.py
+++ b/bioimageio/core/prediction.py
@@ -200,7 +200,7 @@ def predict_with_tiling_impl(
         raise NotImplementedError("Tiling with multiple inputs not implemented yet")
 
     if len(outputs) > 1:
-        raise NotImplementedError("Tiling with multiple inputs not implemented yet")
+        raise NotImplementedError("Tiling with multiple outputs not implemented yet")
 
     assert len(tile_shapes) == len(outputs)
     assert len(halos) == len(outputs)

--- a/bioimageio/core/prediction.py
+++ b/bioimageio/core/prediction.py
@@ -307,7 +307,7 @@ def predict_with_tiling(prediction_pipeline: PredictionPipeline, inputs, tiling)
 
 def parse_padding(padding, model):
     if len(model.inputs) > 1:
-        raise NotImplementedError("Tiling for multiple inputs not yet implemented")
+        raise NotImplementedError("Padding for multiple inputs not yet implemented")
 
     input_spec = model.inputs[0]
     pad_keys = tuple(input_spec.axes) + ("mode",)

--- a/bioimageio/core/prediction.py
+++ b/bioimageio/core/prediction.py
@@ -1,8 +1,10 @@
+import collections
 import os
 import warnings
 from copy import deepcopy
 from itertools import product
 from pathlib import Path
+from typing import Dict, List, OrderedDict, Sequence, Tuple, Union
 
 import imageio
 import numpy as np
@@ -10,13 +12,14 @@ import xarray as xr
 
 from bioimageio.core import load_resource_description
 from bioimageio.core.resource_io.nodes import Model
-from bioimageio.core.prediction_pipeline import create_prediction_pipeline
+from bioimageio.core.prediction_pipeline import PredictionPipeline, create_prediction_pipeline
 from tqdm import tqdm
 
 
 #
 # utility functions for prediction
 #
+from bioimageio.core.resource_io.nodes import ImplicitOutputShape, URI
 
 
 def require_axes(im, axes):
@@ -48,7 +51,7 @@ def require_axes(im, axes):
     return im
 
 
-def pad(im, axes, padding, pad_right=True):
+def pad(im, axes: Sequence[str], padding, pad_right=True) -> Tuple[np.ndarray, Dict[str, slice]]:
     assert im.ndim == len(axes), f"{im.ndim}, {len(axes)}"
 
     padding_ = deepcopy(padding)
@@ -82,10 +85,6 @@ def pad(im, axes, padding, pad_right=True):
 
             pad_width.append([0, pwidth] if pr else [pwidth, 0])
             crop[ax] = slice(0, dlen) if pr else slice(pwidth, None)
-
-        elif ax in "zyx" and mode == "fixed":
-            pad_to = padding_[ax]
-
         else:
             pad_width.append([0, 0])
             crop[ax] = slice(None)
@@ -172,8 +171,7 @@ def get_tiling(shape, tile_shape, halo, input_axes):
         outer_tile["c"] = slice(None)
 
         inner_tile = {
-            ax: slice(pos, min(pos + tsh, sh))
-            for ax, pos, tsh, sh in zip(spatial_axes, positions, tile_shape_, shape_)
+            ax: slice(pos, min(pos + tsh, sh)) for ax, pos, tsh, sh in zip(spatial_axes, positions, tile_shape_, shape_)
         }
         inner_tile["b"] = slice(None)
         inner_tile["c"] = slice(None)
@@ -181,7 +179,7 @@ def get_tiling(shape, tile_shape, halo, input_axes):
         local_tile = {
             ax: slice(
                 inner_tile[ax].start - outer_tile[ax].start,
-                -(outer_tile[ax].stop - inner_tile[ax].stop) if outer_tile[ax].stop != inner_tile[ax].stop else None
+                -(outer_tile[ax].stop - inner_tile[ax].stop) if outer_tile[ax].stop != inner_tile[ax].stop else None,
             )
             for ax in spatial_axes
         }
@@ -191,11 +189,31 @@ def get_tiling(shape, tile_shape, halo, input_axes):
         yield outer_tile, inner_tile, local_tile
 
 
-def predict_with_tiling_impl(prediction_pipeline, input_, output, tile_shape, halo, input_axes):
-    assert input_.ndim == len(input_axes), f"{input_.ndim}, {len(input_axes)}"
+def predict_with_tiling_impl(
+    prediction_pipeline,
+    inputs: List[xr.DataArray],
+    outputs: List[xr.DataArray],
+    tile_shapes: List[dict],
+    halos: List[dict],
+):
+    if len(inputs) > 1:
+        raise NotImplementedError("Tiling with multiple inputs not implemented yet")
 
-    input_ = xr.DataArray(input_, dims=input_axes)
-    tiles = get_tiling(input_.shape, tile_shape, halo, input_axes)
+    if len(outputs) > 1:
+        raise NotImplementedError("Tiling with multiple inputs not implemented yet")
+
+    assert len(tile_shapes) == len(outputs)
+    assert len(halos) == len(outputs)
+
+    input_ = inputs[0]
+    output = outputs[0]
+    tile_shape = tile_shapes[0]
+    halo = halos[0]
+
+    tiles = get_tiling(shape=input_.shape, tile_shape=tile_shape, halo=halo, input_axes=input_.dims)
+
+    assert all(isinstance(ax, str) for ax in input_.dims)
+    input_axes: Tuple[str, ...] = input_.dims  # noqa
 
     def load_tile(tile):
         inp = input_[tile]
@@ -211,75 +229,85 @@ def predict_with_tiling_impl(prediction_pipeline, input_, output, tile_shape, ha
     for outer_tile, inner_tile, local_tile in tiles:
         inp, pad_right = load_tile(outer_tile)
         out = predict_with_padding(prediction_pipeline, inp, padding, pad_right)
+        assert len(out) == 1
+        out = out[0]
         output[inner_tile] = out[local_tile]
 
 
 #
 # prediction functions
-# TODO support models with multiple in/outputs
 #
 
 
-def predict(prediction_pipeline, inputs):
-    if isinstance(inputs, np.ndarray):
+def predict(prediction_pipeline, inputs) -> List[xr.DataArray]:
+    if not isinstance(inputs, (tuple, list)):
         inputs = [inputs]
-    if len(inputs) > 1:
-        raise NotImplementedError(len(inputs))
-    axes = tuple(prediction_pipeline.input_axes)
-    tagged_data = [xr.DataArray(ipt, dims=axes) for ipt in inputs]
+
+    tagged_data = [xr.DataArray(ipt, dims=axes) for ipt, axes in zip(inputs, prediction_pipeline.input_axes)]
     return prediction_pipeline.forward(*tagged_data)
 
 
-def predict_with_padding(prediction_pipeline, inputs, padding, pad_right=True):
-    if isinstance(inputs, (np.ndarray, xr.DataArray)):
+def predict_with_padding(prediction_pipeline, inputs, padding, pad_right=True) -> List[xr.DataArray]:
+    if not isinstance(inputs, (tuple, list)):
         inputs = [inputs]
-    axes = tuple(prediction_pipeline.input_axes)
-    inputs = [pad(inp, axes, padding, pad_right=pad_right) for inp in inputs]
-    inputs, crops = [inp[0] for inp in inputs], [inp[1] for inp in inputs]
+
+    inputs, crops = zip(
+        *[pad(inp, axes, padding, pad_right=pad_right) for inp, axes in zip(inputs, prediction_pipeline.input_axes)]
+    )
+
     result = predict(prediction_pipeline, inputs)
-    if isinstance(result, (list, tuple)):
-        result = [apply_crop(res, crop) for res, crop in zip(result, crops)]
-    else:
-        result = apply_crop(result, crops[0])
-    return result
+    return [apply_crop(res, crop) for res, crop in zip(result, crops)]
 
 
-def predict_with_tiling(prediction_pipeline, inputs, tiling):
-    if isinstance(inputs, (list, tuple)):
-        if len(inputs) > 1:
-            raise NotImplementedError(len(inputs))
-        input_ = inputs[0]
-    else:
-        input_ = inputs
-    input_axes = tuple(prediction_pipeline.input_axes)
+def predict_with_tiling(prediction_pipeline: PredictionPipeline, inputs, tiling) -> List[xr.DataArray]:
+    if not isinstance(inputs, (list, tuple)):
+        inputs = [inputs]
 
-    output_axes = tuple(prediction_pipeline.output_axes)
-    # NOTE there could also be models with a fixed output shape, but this is currently
-    # not reflected in prediction_pipeline, need to adapt this here once fixed
-    scale, offset = prediction_pipeline.scale, prediction_pipeline.offset
-    scale, offset = {sc[0]: sc[1] for sc in scale}, {off[0]: off[1] for off in offset}
+    assert len(inputs) == len(prediction_pipeline.input_specs)
+    named_inputs: OrderedDict[str, xr.DataArray] = collections.OrderedDict(
+        **{
+            ipt_spec.name: xr.DataArray(ipt_data, dims=tuple(ipt_spec.axes))
+            for ipt_data, ipt_spec in zip(inputs, prediction_pipeline.input_specs)
+        }
+    )
 
-    # for now, we only support tiling if the spatial shape doesn't change
-    # supporting this should not be so difficult, we would just need to apply the inverse
-    # to "out_shape = scale * in_shape + 2 * offset" ("in_shape = (out_shape - 2 * offset) / scale")
-    # to 'outer_tile' in 'get_tiling'
-    if any(scale[ax] != 1 for ax in output_axes if ax in "xyz") or\
-       any(offset[ax] != 0 for ax in output_axes if ax in "xyz"):
-        raise NotImplementedError("Tiling with a different output shape is not yet supported")
+    outputs = []
+    for output_spec in prediction_pipeline.output_specs:
+        if isinstance(output_spec.shape, ImplicitOutputShape):
+            scale = dict(zip(output_spec.axes, output_spec.shape.scale))
+            offset = dict(zip(output_spec.axes, output_spec.shape.offset))
 
-    out_shape = tuple(int(scale[ax] * input_.shape[input_axes.index(ax)] + 2 * offset[ax]) for ax in output_axes)
-    # TODO the dtype information is missing from prediction pipeline
-    out_dtype = "float32"
-    output = xr.DataArray(np.zeros(out_shape, dtype=out_dtype), dims=output_axes)
+            # for now, we only support tiling if the spatial shape doesn't change
+            # supporting this should not be so difficult, we would just need to apply the inverse
+            # to "out_shape = scale * in_shape + 2 * offset" ("in_shape = (out_shape - 2 * offset) / scale")
+            # to 'outer_tile' in 'get_tiling'
+            if any(sc != 1 for ax, sc in scale.items() if ax in "xyz") or any(
+                off != 0 for ax, off in offset.items() if ax in "xyz"
+            ):
+                raise NotImplementedError("Tiling with a different output shape is not yet supported")
 
-    halo = tiling["halo"]
-    tile_shape = tiling["tile"]
+            ref_input = named_inputs[output_spec.shape.reference_input]
+            ref_input_shape = dict(zip(ref_input.dims, ref_input.shape))
+            output_shape = tuple(int(scale[ax] * ref_input_shape[ax] + 2 * offset[ax]) for ax in output_spec.axes)
+        else:
+            output_shape = tuple(output_spec.shape)
 
-    predict_with_tiling_impl(prediction_pipeline, input_, output, tile_shape, halo, input_axes)
-    return output
+        outputs.append(xr.DataArray(np.zeros(output_shape, dtype=output_spec.data_type), dims=tuple(output_spec.axes)))
+
+    predict_with_tiling_impl(
+        prediction_pipeline,
+        list(named_inputs.values()),
+        outputs,
+        tile_shapes=[tiling["tile"]],  # todo: update tiling for multiple inputs/outputs
+        halos=[tiling["halo"]],
+    )
+
+    return outputs
 
 
 def parse_padding(padding, model):
+    if len(model.inputs) > 1:
+        raise NotImplementedError("Tiling for multiple inputs not yet implemented")
 
     input_spec = model.inputs[0]
     pad_keys = tuple(input_spec.axes) + ("mode",)
@@ -311,6 +339,12 @@ def parse_padding(padding, model):
 
 
 def parse_tiling(tiling, model):
+    if len(model.inputs) > 1:
+        raise NotImplementedError("Tiling for multiple inputs not yet implemented")
+
+    if len(model.outputs) > 1:
+        raise NotImplementedError("Tiling for multiple outputs not yet implemented")
+
     input_spec = model.inputs[0]
     output_spec = model.outputs[0]
 
@@ -347,19 +381,15 @@ def parse_tiling(tiling, model):
     return tiling
 
 
-# TODO support models with multiple in/outputs
 def predict_image(model_rdf, inputs, outputs, padding=None, tiling=None, weight_format=None, devices=None):
     """Run prediction for a single set of inputs with a bioimage.io model."""
-    if isinstance(inputs, (str, Path)):
+    if not isinstance(inputs, (tuple, list)):
         inputs = [inputs]
-    if len(inputs) > 1:
-        raise NotImplementedError(len(inputs))
-    if isinstance(outputs, (str, Path)):
-        outputs = [outputs]
-    if len(outputs) > 1:
-        raise NotImplementedError(len(outputs))
 
-    model = load_resource_description(Path(model_rdf))
+    if not isinstance(outputs, (tuple, list)):
+        outputs = [outputs]
+
+    model = load_resource_description(model_rdf)
     assert isinstance(model, Model)
     if len(model.inputs) != len(inputs):
         raise ValueError
@@ -369,14 +399,13 @@ def predict_image(model_rdf, inputs, outputs, padding=None, tiling=None, weight_
     prediction_pipeline = create_prediction_pipeline(
         bioimageio_model=model, weight_format=weight_format, devices=devices
     )
-    axes = tuple(prediction_pipeline.input_axes)
 
     padding = parse_padding(padding, model)
     tiling = parse_tiling(tiling, model)
     if padding is not None and tiling is not None:
         raise ValueError("Only one of padding or tiling is supported")
 
-    input_data = [load_image(inp, axes) for inp in inputs]
+    input_data = [load_image(inp, axes) for inp, axes in zip(inputs, prediction_pipeline.input_axes)]
     if padding is not None:
         result = predict_with_padding(prediction_pipeline, input_data, padding)
     elif tiling is not None:
@@ -384,38 +413,29 @@ def predict_image(model_rdf, inputs, outputs, padding=None, tiling=None, weight_
     else:
         result = predict(prediction_pipeline, input_data)
 
-    if isinstance(result, list):
-        assert len(result) == len(outputs)
-        for res, out in zip(result, outputs):
-            save_image(out, res)
-    else:
-        assert len(outputs) == 1
-        save_image(outputs[0], result)
+    assert isinstance(result, list)
+    assert len(result) == len(outputs)
+    for res, out in zip(result, outputs):
+        save_image(out, res)
 
 
 def predict_images(
     model_rdf,
-    inputs,
-    outputs,
+    inputs: Sequence[Union[Tuple[Path, ...], List[Path], Path]],
+    outputs: Sequence[Union[Tuple[Path, ...], List[Path], Path]],
     padding=None,
     tiling=None,
     weight_format=None,
     devices=None,
-    verbose=False
+    verbose=False,
 ):
-    """Predict multiple inputs with a bioimage.io model.
-
-    Only works for models with a single input and output tensor.
-    """
-    model = load_resource_description(Path(model_rdf))
+    """Predict multiple inputs with a bioimage.io model."""
+    model = load_resource_description(model_rdf)
     assert isinstance(model, Model)
-    if len(model.inputs) > 1 or len(model.outputs) > 1:
-        raise ValueError("predict_images only supports models that have a single input/output tensor")
 
     prediction_pipeline = create_prediction_pipeline(
         bioimageio_model=model, weight_format=weight_format, devices=devices
     )
-    axes = tuple(prediction_pipeline.input_axes)
 
     padding = parse_padding(padding, model)
     tiling = parse_tiling(tiling, model)
@@ -427,32 +447,42 @@ def predict_images(
         prog = tqdm(prog, total=len(inputs))
 
     for inp, outp in prog:
-        inp = load_image(inp, axes)
+        if not isinstance(inp, (tuple, list)):
+            inp = [inp]
+
+        if not isinstance(outp, (tuple, list)):
+            outp = [outp]
+
+        inp = [load_image(im, sp.axes) for im, sp in zip(inp, prediction_pipeline.input_specs)]
         if padding is not None:
             res = predict_with_padding(prediction_pipeline, inp, padding)
         elif tiling is not None:
             res = predict_with_tiling(prediction_pipeline, inp, tiling)
         else:
             res = predict(prediction_pipeline, inp)
-        save_image(outp, res)
+
+        assert isinstance(res, list)
+        for out, r in zip(outp, res):
+            save_image(out, r)
 
 
-def test_model(model_rdf, weight_format=None, devices=None, decimal=4):
+def test_model(model_rdf: Union[URI, Path, str], weight_format=None, devices=None, decimal=4):
     """Test whether the test output(s) of a model can be reproduced.
 
     Returns True if the test passes, otherwise returns False and issues a warning.
     """
-    model = load_resource_description(Path(model_rdf))
+    print(model_rdf, Path(model_rdf).exists())
+    model = load_resource_description(model_rdf)
     assert isinstance(model, Model)
     prediction_pipeline = create_prediction_pipeline(
         bioimageio_model=model, devices=devices, weight_format=weight_format
     )
-    inputs = [np.load(in_path) for in_path in model.test_inputs]
+    inputs = [np.load(str(in_path)) for in_path in model.test_inputs]
     results = predict(prediction_pipeline, inputs)
     if isinstance(results, (np.ndarray, xr.DataArray)):
         results = [results]
 
-    expected = [np.load(out_path) for out_path in model.test_outputs]
+    expected = [np.load(str(out_path)) for out_path in model.test_outputs]
     if len(results) != len(expected):
         warnings.warn(f"Number of outputs and number of expected outputs disagree: {len(results)} != {len(expected)}")
         return False

--- a/bioimageio/core/prediction.py
+++ b/bioimageio/core/prediction.py
@@ -251,8 +251,17 @@ def predict_with_padding(prediction_pipeline, inputs, padding, pad_right=True) -
     if not isinstance(inputs, (tuple, list)):
         inputs = [inputs]
 
+    assert len(inputs) == len(prediction_pipeline.input_specs)
+
+    if not isinstance(padding, (tuple, list)):
+        padding = [padding]
+
+    assert len(padding) == len(prediction_pipeline.input_specs)
     inputs, crops = zip(
-        *[pad(inp, axes, padding, pad_right=pad_right) for inp, axes in zip(inputs, prediction_pipeline.input_axes)]
+        *[
+            pad(inp, spec.axes, p, pad_right=pad_right)
+            for inp, spec, p in zip(inputs, prediction_pipeline.input_specs, padding)
+        ]
     )
 
     result = predict(prediction_pipeline, inputs)

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_keras_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_keras_model_adapter.py
@@ -10,15 +10,11 @@ from ._model_adapter import ModelAdapter
 
 class KerasModelAdapter(ModelAdapter):
     def __init__(self, *, bioimageio_model: nodes.Model, devices: Optional[List[str]] = None):
-        self.spec = bioimageio_model
-        self.name = self.spec.name
-
         # TODO keras device management
         if devices is not None:
             warnings.warn(f"Device management is not implemented for tensorflow yet, ignoring the devices {devices}")
-        self.devices = []
 
-        weight_file = self.spec.weights["keras_hdf5"].source
+        weight_file = bioimageio_model.weights["keras_hdf5"].source
         self._model = keras.models.load_model(weight_file)
         self._output_axes = [tuple(out.axes) for out in bioimageio_model.outputs]
 

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_keras_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_keras_model_adapter.py
@@ -19,7 +19,7 @@ class KerasModelAdapter(ModelAdapter):
         self._output_axes = [tuple(out.axes) for out in bioimageio_model.outputs]
 
     def forward(self, *input_tensors: xr.DataArray) -> List[xr.DataArray]:
-        result = self._model.predict(*[ipt.data for ipt in input_tensors])
+        result = self._model.predict(*input_tensors)
         if not isinstance(result, (tuple, list)):
             result = [result]
 

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_model_adapter.py
@@ -1,5 +1,5 @@
 import abc
-from typing import List, Optional, Type
+from typing import Any, List, Optional, Type, Union
 
 import xarray as xr
 from bioimageio.core.resource_io import nodes
@@ -20,7 +20,7 @@ class ModelAdapter(abc.ABC):
 
     # todo: separate preprocessing/actual forward/postprocessing
     @abc.abstractmethod
-    def forward(self, input_tensor: xr.DataArray) -> xr.DataArray:
+    def forward(self, *input_tensors: xr.DataArray) -> List[xr.DataArray]:
         """
         Run forward pass of model to get model predictions
         Note: model is responsible converting it's data representation to

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_onnx_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_onnx_model_adapter.py
@@ -14,28 +14,20 @@ logger = logging.getLogger(__name__)
 class ONNXModelAdapter(ModelAdapter):
     def __init__(self, *, bioimageio_model: nodes.Model, devices: Optional[List[str]] = None):
         spec = bioimageio_model
-        self.name = spec.name
 
-        if len(spec.inputs) != 1 or len(spec.outputs) != 1:
-            raise NotImplementedError("Only single input, single output models are supported")
-
-        assert len(spec.inputs) == 1
-        assert len(spec.outputs) == 1
-
-        spec.inputs[0]
-        _output = spec.outputs[0]
-
-        self._internal_output_axes = _output.axes
+        self._internal_output_axes = [tuple(out.axes) for out in bioimageio_model.outputs]
 
         self._session = rt.InferenceSession(str(spec.weights["onnx"].source))
         onnx_inputs = self._session.get_inputs()
-        assert len(onnx_inputs) == 1, f"expected onnx model to have one input got {len(onnx_inputs)}"
-        self._input_name = onnx_inputs[0].name
-        # TODO onnx device management
-        self.devices = []
+        self._input_names = [ipt.name for ipt in onnx_inputs]
+
         if devices is not None:
             warnings.warn(f"Device management is not implemented for onnx yet, ignoring the devices {devices}")
 
-    def forward(self, input: xr.DataArray) -> xr.DataArray:
-        result = self._session.run(None, {self._input_name: input.data})[0]
-        return xr.DataArray(result, dims=tuple(self._internal_output_axes))
+    def forward(self, *input_tensors: xr.DataArray) -> List[xr.DataArray]:
+        assert len(input_tensors) == len(self._input_names)
+        result = self._session.run(None, dict(zip(self._input_names, input_tensors)))
+        if not isinstance(result, (list, tuple)):
+            result = []
+
+        return [xr.DataArray(r, dims=axes) for r, axes in zip(result, self._internal_output_axes)]

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_onnx_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_onnx_model_adapter.py
@@ -26,7 +26,8 @@ class ONNXModelAdapter(ModelAdapter):
 
     def forward(self, *input_tensors: xr.DataArray) -> List[xr.DataArray]:
         assert len(input_tensors) == len(self._input_names)
-        result = self._session.run(None, dict(zip(self._input_names, input_tensors)))
+        input_arrays = [ipt.data for ipt in input_tensors]
+        result = self._session.run(None, dict(zip(self._input_names, input_arrays)))
         if not isinstance(result, (list, tuple)):
             result = []
 

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_torchscript_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_torchscript_model_adapter.py
@@ -30,5 +30,4 @@ class TorchscriptModelAdapter(ModelAdapter):
             result = [r.cpu().numpy() if not isinstance(r, np.ndarray) else r for r in result]
 
         assert len(result) == len(self._internal_output_axes)
-        result = [xr.DataArray(r, dims=axes) for r, axes in zip(result, self._internal_output_axes)]
-        return result
+        return [xr.DataArray(r, dims=axes) for r, axes in zip(result, self._internal_output_axes)]

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_torchscript_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_torchscript_model_adapter.py
@@ -10,30 +10,25 @@ from ._model_adapter import ModelAdapter
 
 class TorchscriptModelAdapter(ModelAdapter):
     def __init__(self, *, bioimageio_model: nodes.Model, devices: Optional[List[str]] = None):
-        spec = bioimageio_model
-        self.name = spec.name
-
-        _input = spec.inputs[0]
-        _output = spec.outputs[0]
-
-        self._internal_input_axes = _input.axes
-        self._internal_output_axes = _output.axes
-
+        weight_path = str(bioimageio_model.weights["pytorch_script"].source.resolve())
         if devices is None:
-            self.devices = ["cuda" if torch.cuda.is_available() else "cpu"]
+            devices = ["cuda" if torch.cuda.is_available() else "cpu"]
         else:
-            self.devices = [torch.device(d) for d in devices]
+            devices = [torch.device(d) for d in devices]
 
-        weight_path = str(spec.weights["pytorch_script"].source.resolve())
-        self.model = torch.jit.load(weight_path)
-        self.model.to(self.devices[0])
+        self._model = torch.jit.load(weight_path)
+        self._model.to(devices[0])
+        self._internal_output_axes = [tuple(out.axes) for out in bioimageio_model.outputs]
 
-    def forward(self, batch: xr.DataArray) -> xr.DataArray:
+    def forward(self, *batch: xr.DataArray) -> List[xr.DataArray]:
         with torch.no_grad():
-            torch_tensor = torch.from_numpy(batch.data)
-            result = self.model.forward(torch_tensor)
+            torch_tensor = [torch.from_numpy(b.data) for b in batch]
+            result = self._model.forward(*torch_tensor)
+            if not isinstance(result, (tuple, list)):
+                result = [result]
 
-            if not isinstance(result, np.ndarray):
-                result = result.cpu().numpy()
+            result = [r.cpu().numpy() if not isinstance(r, np.ndarray) else r for r in result]
 
-        return xr.DataArray(result, dims=tuple(self._internal_output_axes))
+        assert len(result) == len(self._internal_output_axes)
+        result = [xr.DataArray(r, dims=axes) for r, axes in zip(result, self._internal_output_axes)]
+        return result

--- a/bioimageio/core/prediction_pipeline/_prediction_pipeline.py
+++ b/bioimageio/core/prediction_pipeline/_prediction_pipeline.py
@@ -73,7 +73,7 @@ class PredictionPipeline(ModelAdapter):
 
     @property
     @abc.abstractmethod
-    def output_shape(self) -> List[Union[List[Tuple[str, float]]], NamedImplicitOutputShape]:
+    def output_shape(self) -> List[Union[List[Tuple[str, float]], NamedImplicitOutputShape]]:
         """
         Named output dimensions. Either explicitly defined or implicitly in relation to an input
         """
@@ -96,7 +96,7 @@ class _PredictionPipelineImpl(PredictionPipeline):
         input_axes: Sequence[str],
         input_shape: Sequence[List[Tuple[str, int]]],
         output_axes: Sequence[str],
-        output_shape: Sequence[Union[List[Tuple[str, int]]], NamedImplicitOutputShape],
+        output_shape: Sequence[Union[List[Tuple[str, int]], NamedImplicitOutputShape]],
         halo: Sequence[List[Tuple[str, int]]],
         preprocessing: Sequence[Transform],
         model: ModelAdapter,

--- a/bioimageio/core/prediction_pipeline/_prediction_pipeline.py
+++ b/bioimageio/core/prediction_pipeline/_prediction_pipeline.py
@@ -12,7 +12,7 @@ from ._postprocessing import make_postprocessing
 
 from ._preprocessing import make_preprocessing
 from ._types import Transform
-from ..resource_io.nodes import ImplicitOutputShape
+from ..resource_io.nodes import ImplicitOutputShape, InputTensor, OutputTensor
 
 
 @dataclass
@@ -47,7 +47,24 @@ class PredictionPipeline(ModelAdapter):
 
     @property
     @abc.abstractmethod
-    def input_axes(self) -> List[str]:
+    def input_specs(self) -> List[InputTensor]:
+        """
+        specs of inputs
+        """
+        ...
+
+    @property
+    @abc.abstractmethod
+    def output_specs(self) -> List[OutputTensor]:
+        """
+        specs of outputs
+        """
+        ...
+
+    # todo: replace all uses of properties below with 'input_specs' and 'output_specs'
+    @property
+    @abc.abstractmethod
+    def input_axes(self) -> List[Tuple[str, ...]]:
         """
         Input axes excepted by this pipeline
         Note: one character axes names
@@ -64,7 +81,7 @@ class PredictionPipeline(ModelAdapter):
 
     @property
     @abc.abstractmethod
-    def output_axes(self) -> List[str]:
+    def output_axes(self) -> List[Tuple[str, ...]]:
         """
         Output axes of this pipeline
         Note: one character axes names
@@ -103,9 +120,9 @@ class _PredictionPipelineImpl(PredictionPipeline):
         postprocessing: Sequence[Transform],
     ) -> None:
         self._name = name
-        self._input_axes = input_axes
+        self._input_axes = [tuple(axes) for axes in input_axes]
         self._input_shape = input_shape
-        self._output_axes = output_axes
+        self._output_axes = [tuple(axes) for axes in output_axes]
         self._output_shape = output_shape
         self._halo = halo
         self._preprocessing = preprocessing

--- a/bioimageio/core/prediction_pipeline/_prediction_pipeline.py
+++ b/bioimageio/core/prediction_pipeline/_prediction_pipeline.py
@@ -1,6 +1,7 @@
 import abc
 import math
-from typing import List, Optional, Tuple
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Tuple, Union
 
 import xarray as xr
 from bioimageio.core.resource_io import nodes
@@ -9,9 +10,19 @@ from marshmallow import missing
 from ._model_adapters import ModelAdapter, create_model_adapter
 from ._postprocessing import make_postprocessing
 
-# from ._preprocessing import ADD_BATCH_DIM, make_ensure_dtype_preprocessing
 from ._preprocessing import make_preprocessing
 from ._types import Transform
+from ..resource_io.nodes import ImplicitOutputShape
+
+
+@dataclass
+class NamedImplicitOutputShape:
+    reference_input: str = missing
+    scale: List[Tuple[str, float]] = missing
+    offset: List[Tuple[str, int]] = missing
+
+    def __len__(self):
+        return len(self.scale)
 
 
 class PredictionPipeline(ModelAdapter):
@@ -20,7 +31,7 @@ class PredictionPipeline(ModelAdapter):
     """
 
     @abc.abstractmethod
-    def forward(self, input_tensor: xr.DataArray) -> xr.DataArray:
+    def forward(self, *input_tensors: xr.DataArray) -> List[xr.DataArray]:
         """
         Compute predictions
         """
@@ -36,7 +47,7 @@ class PredictionPipeline(ModelAdapter):
 
     @property
     @abc.abstractmethod
-    def input_axes(self) -> str:
+    def input_axes(self) -> List[str]:
         """
         Input axes excepted by this pipeline
         Note: one character axes names
@@ -45,7 +56,7 @@ class PredictionPipeline(ModelAdapter):
 
     @property
     @abc.abstractmethod
-    def input_shape(self) -> List[Tuple[str, int]]:
+    def input_shape(self) -> List[List[Tuple[str, int]]]:
         """
         Named input dimensions
         """
@@ -53,7 +64,7 @@ class PredictionPipeline(ModelAdapter):
 
     @property
     @abc.abstractmethod
-    def output_axes(self) -> str:
+    def output_axes(self) -> List[str]:
         """
         Output axes of this pipeline
         Note: one character axes names
@@ -62,25 +73,17 @@ class PredictionPipeline(ModelAdapter):
 
     @property
     @abc.abstractmethod
-    def halo(self) -> List[Tuple[str, int]]:
+    def output_shape(self) -> List[Union[List[Tuple[str, float]]], NamedImplicitOutputShape]:
         """
-        Size of output borders that have unreliable data due to artifacts
-        """
-        ...
-
-    @property
-    @abc.abstractmethod
-    def scale(self) -> List[Tuple[str, float]]:
-        """
-        Scale of output tensor relative to input
+        Named output dimensions. Either explicitly defined or implicitly in relation to an input
         """
         ...
 
     @property
     @abc.abstractmethod
-    def offset(self) -> List[Tuple[str, int]]:
+    def halo(self) -> List[List[Tuple[str, int]]]:
         """
-        Offset of output tensor relative to input
+        Size of output borders that have unreliable data due to artifacts (after application of postprocessing)
         """
         ...
 
@@ -90,23 +93,21 @@ class _PredictionPipelineImpl(PredictionPipeline):
         self,
         *,
         name: str,
-        input_axes: str,  # TODO shouldn't this be a list for multple input tensors?
-        input_shape: List[Tuple[str, int]],
-        output_axes: str,
-        halo: List[Tuple[str, int]],
-        scale: List[Tuple[str, float]],
-        offset: List[Tuple[str, int]],
-        preprocessing: Transform,
+        input_axes: Sequence[str],
+        input_shape: Sequence[List[Tuple[str, int]]],
+        output_axes: Sequence[str],
+        output_shape: Sequence[Union[List[Tuple[str, int]]], NamedImplicitOutputShape],
+        halo: Sequence[List[Tuple[str, int]]],
+        preprocessing: Sequence[Transform],
         model: ModelAdapter,
-        postprocessing: Transform,
+        postprocessing: Sequence[Transform],
     ) -> None:
         self._name = name
-        self._halo = halo
-        self._scale = scale
-        self._offset = offset
         self._input_axes = input_axes
-        self._output_axes = output_axes
         self._input_shape = input_shape
+        self._output_axes = output_axes
+        self._output_shape = output_shape
+        self._halo = halo
         self._preprocessing = preprocessing
         self._model: ModelAdapter = model
         self._postprocessing = postprocessing
@@ -116,49 +117,49 @@ class _PredictionPipelineImpl(PredictionPipeline):
         return self._name
 
     @property
-    def halo(self):
-        return self._halo
-
-    @property
-    def scale(self):
-        return self._scale
-
-    @property
-    def offset(self):
-        return self._offset
-
-    @property
     def input_axes(self):
         return self._input_axes
+
+    @property
+    def input_shape(self):
+        return self._input_shape
 
     @property
     def output_axes(self):
         return self._output_axes
 
     @property
-    def input_shape(self):
-        return self._input_shape
+    def output_shape(self):
+        return self._output_shape
 
-    def predict(self, input_tensor: xr.DataArray) -> xr.DataArray:
+    @property
+    def halo(self):
+        return self._halo
+
+    def predict(self, *input_tensors: xr.DataArray) -> List[xr.DataArray]:
         """Predict input_tensor with the model without applying pre/postprocessing."""
-        return self._model.forward(input_tensor)
+        return self._model.forward(*input_tensors)
 
-    def forward(self, input_tensor: xr.DataArray) -> xr.DataArray:
+    def forward(self, *input_tensors: xr.DataArray) -> List[xr.DataArray]:
         """Apply preprocessing, run prediction and apply postprocessing."""
-        preprocessed = self._preprocessing(input_tensor)
-        prediction = self.predict(preprocessed)
-        return self._postprocessing(prediction)
+        assert len(self._preprocessing) == len(input_tensors)
+        preprocessed = [fn(x) for fn, x in zip(self._preprocessing, input_tensors)]
+        prediction = self.predict(*preprocessed)
+        assert len(self._postprocessing) == len(prediction)
+        return [fn(x) for fn, x in zip(self._postprocessing, prediction)]
 
-    def preprocess(self, input_tensor: xr.DataArray) -> xr.DataArray:
+    def preprocess(self, *input_tensors: xr.DataArray) -> List[xr.DataArray]:
         """Apply preprocessing."""
-        return self._preprocessing(input_tensor)
+        assert len(self._preprocessing) == len(input_tensors)
+        return [fn(x) for fn, x in zip(self._preprocessing, input_tensors)]
 
-    def postprocess(self, input_tensor: xr.DataArray) -> xr.DataArray:
+    def postprocess(self, *input_tensors: xr.DataArray) -> List[xr.DataArray]:
         """Apply postprocessing."""
-        return self._postprocessing(input_tensor)
+        assert len(self._postprocessing) == len(input_tensors)
+        return [fn(x) for fn, x in zip(self._postprocessing, input_tensors)]
 
-    def __call__(self, input_tensor: xr.DataArray) -> xr.DataArray:
-        return self.forward(input_tensor)
+    def __call__(self, *input_tensors: xr.DataArray) -> List[xr.DataArray]:
+        return self.forward(*input_tensors)
 
 
 def enforce_min_shape(min_shape, step, axes):
@@ -197,53 +198,56 @@ def create_prediction_pipeline(
     * model prediction
     * postprocessing
     """
-    if len(bioimageio_model.inputs) != 1 or len(bioimageio_model.outputs) != 1:
-        raise NotImplementedError("Only models with single input and output are supported")
-
     model_adapter: ModelAdapter = create_model_adapter(
         bioimageio_model=bioimageio_model, devices=devices, weight_format=weight_format
     )
 
-    input = bioimageio_model.inputs[0]
-    input_axes = input.axes
-    try:
-        input_shape = input.shape.min
-        step = input.shape.step
-        input_shape = enforce_min_shape(input_shape, step, input_axes)
-    except AttributeError:
-        input_shape = input.shape
+    input_axes: List[str] = []
+    named_input_shape: List[List[Tuple[str, int]]] = []
+    preprocessing: List[Transform] = []
+    for ipt in bioimageio_model.inputs:
+        try:
+            input_shape = ipt.shape.min
+            step = ipt.shape.step
+            input_shape = enforce_min_shape(input_shape, step, ipt.axes)
+        except AttributeError:
+            input_shape = ipt.shape
 
-    preprocessing_spec = [] if input.preprocessing is missing else input.preprocessing.copy()
+        input_axes.append(ipt.axes)
+        named_input_shape.append(list(zip(ipt.axes, input_shape)))
+        preprocessing_spec = [] if ipt.preprocessing is missing else ipt.preprocessing.copy()
+        preprocessing.append(make_preprocessing(preprocessing_spec))
 
-    input_named_shape = list(zip(input_axes, input_shape))
-    preprocessing: Transform = make_preprocessing(preprocessing_spec)
+    output_axes: List[str] = []
+    named_output_shape: List[Union[List[Tuple[str, int]], NamedImplicitOutputShape]] = []
+    named_halo: List[List[Tuple[str, int]]] = []
+    postprocessing: List[Transform] = []
+    for out in bioimageio_model.outputs:
+        output_axes.append(out.axes)
+        if isinstance(out.shape, list):  # explict output shape
+            named_output_shape.append(list(zip(out.axes, out.shape)))
+        elif isinstance(out.shape, ImplicitOutputShape):
+            named_output_shape.append(
+                NamedImplicitOutputShape(
+                    reference_input=out.shape.reference_input,
+                    scale=list(zip(out.axes, out.shape.scale)),
+                    offset=list(zip(out.axes, out.shape.offset)),
+                )
+            )
+        else:
+            raise TypeError(f"Unexpected type for output shape: {type(out.shape)}")
 
-    output = bioimageio_model.outputs[0]
-    # TODO are we using the halo here at all?
-    halo_shape = output.halo or [0 for _ in output.axes]
-    output_axes = bioimageio_model.outputs[0].axes
-    # TODO don't we also have fixed output shape?
-    scale = output.shape.scale
-    offset = output.shape.offset
-    postprocessing_spec = [] if output.postprocessing is missing else output.postprocessing.copy()
-    halo_named_shape = list(zip(output_axes, halo_shape))
-
-    if isinstance(output.shape, list):
-        raise NotImplementedError("Expected implicit output shape")
-
-    named_scale = list(zip(output_axes, scale))
-    named_offset = list(zip(output_axes, offset))
-
-    postprocessing: Transform = make_postprocessing(postprocessing_spec)
+        named_halo.append(list(zip(out.axes, out.halo or [0 for _ in out.axes])))
+        postprocessing_spec = [] if out.postprocessing is missing else out.postprocessing.copy()
+        postprocessing.append(make_postprocessing(postprocessing_spec))
 
     return _PredictionPipelineImpl(
         name=bioimageio_model.name,
         input_axes=input_axes,
-        input_shape=input_named_shape,
+        input_shape=named_input_shape,
         output_axes=output_axes,
-        halo=halo_named_shape,
-        scale=named_scale,
-        offset=named_offset,
+        output_shape=named_output_shape,
+        halo=named_halo,
         preprocessing=preprocessing,
         model=model_adapter,
         postprocessing=postprocessing,

--- a/bioimageio/core/prediction_pipeline/_prediction_pipeline.py
+++ b/bioimageio/core/prediction_pipeline/_prediction_pipeline.py
@@ -12,7 +12,7 @@ from ._postprocessing import make_postprocessing
 
 from ._preprocessing import make_preprocessing
 from ._types import Transform
-from ..resource_io.nodes import ImplicitOutputShape, InputTensor, OutputTensor
+from ..resource_io.nodes import ImplicitOutputShape, InputTensor, Model, OutputTensor
 
 
 @dataclass
@@ -110,6 +110,7 @@ class _PredictionPipelineImpl(PredictionPipeline):
         self,
         *,
         name: str,
+        bioimageio_model: Model,
         input_axes: Sequence[str],
         input_shape: Sequence[List[Tuple[str, int]]],
         output_axes: Sequence[str],
@@ -120,6 +121,8 @@ class _PredictionPipelineImpl(PredictionPipeline):
         postprocessing: Sequence[Transform],
     ) -> None:
         self._name = name
+        self._input_specs = bioimageio_model.inputs
+        self._output_specs = bioimageio_model.outputs
         self._input_axes = [tuple(axes) for axes in input_axes]
         self._input_shape = input_shape
         self._output_axes = [tuple(axes) for axes in output_axes]
@@ -132,6 +135,14 @@ class _PredictionPipelineImpl(PredictionPipeline):
     @property
     def name(self):
         return self._name
+
+    @property
+    def input_specs(self):
+        return self._input_specs
+
+    @property
+    def output_specs(self):
+        return self._output_specs
 
     @property
     def input_axes(self):
@@ -260,6 +271,7 @@ def create_prediction_pipeline(
 
     return _PredictionPipelineImpl(
         name=bioimageio_model.name,
+        bioimageio_model=bioimageio_model,
         input_axes=input_axes,
         input_shape=named_input_shape,
         output_axes=output_axes,

--- a/bioimageio/core/prediction_pipeline/_preprocessing.py
+++ b/bioimageio/core/prediction_pipeline/_preprocessing.py
@@ -8,13 +8,6 @@ from bioimageio.spec.model.raw_nodes import PreprocessingName
 from ._types import Transform
 
 
-# ADD_BATCH_DIM = Preprocessing(name="__tiktorch_add_batch_dim", kwargs=None)
-
-
-# def make_ensure_dtype_preprocessing(dtype):
-#     return Preprocessing(name="__tiktorch_ensure_dtype", kwargs={"dtype": dtype})
-
-
 def scale_linear(tensor: xr.DataArray, *, gain, offset, axes) -> xr.DataArray:
     """scale the tensor with a fixed multiplicative and additive factor"""
     scale_axes = tuple(ax for ax in tensor.dims if (ax not in axes and ax != "b"))

--- a/tests/build_spec/test_build_spec.py
+++ b/tests/build_spec/test_build_spec.py
@@ -68,16 +68,18 @@ def test_build_spec_torchscript(unet2d_nuclei_broad_model):
     _test_build_spec(unet2d_nuclei_broad_model, "pytorch_script")
 
 
-@pytest.mark.skipif(pytest.skip_frunet, reason="pending update to FruNet")
-def test_build_spec_keras(FruNet_model):
-    _test_build_spec(FruNet_model, "keras_hdf5", tensorflow_version="1.12")
+@pytest.mark.skipif(pytest.skip_tensorflow or pytest.tf_major_version != 1, reason="requires tensorflow 1")
+def test_build_spec_keras(any_keras_model):
+    _test_build_spec(any_keras_model, "keras_hdf5", tensorflow_version="1.12")  # todo: keras for tf 2??
 
 
-@pytest.mark.skipif(pytest.skip_frunet, reason="pending update to FruNet")
-def test_build_spec_tf(FruNet_model):
-    _test_build_spec(FruNet_model, "tensorflow_saved_model_bundle", tensorflow_version="1.12")
+@pytest.mark.skipif(pytest.skip_tensorflow, reason="requires tensorflow")
+def test_build_spec_tf(any_tensorflow_model):
+    _test_build_spec(
+        any_tensorflow_model, "tensorflow_saved_model_bundle", tensorflow_version="1.12"
+    )  # check tf version
 
 
-@pytest.mark.skipif(pytest.skip_frunet, reason="pending update to FruNet")
-def test_build_spec_tfjs(FruNet_model):
-    _test_build_spec(FruNet_model, "tensorflow_js", tensorflow_version="1.12")
+@pytest.mark.skipif(pytest.skip_tensorflow, reason="requires tensorflow")
+def test_build_spec_tfjs(any_tensorflow_js_model):
+    _test_build_spec(any_tensorflow_js_model, "tensorflow_js", tensorflow_version="1.12")

--- a/tests/build_spec/test_build_spec.py
+++ b/tests/build_spec/test_build_spec.py
@@ -56,14 +56,17 @@ def _test_build_spec(path, weight_type, tensorflow_version=None):
     spec.model.schema.Model().dump(raw_model)
 
 
+@pytest.mark.skipif(pytest.skip_torch, reason="requires torch")
 def test_build_spec_pytorch(unet2d_nuclei_broad_model):
     _test_build_spec(unet2d_nuclei_broad_model, "pytorch_state_dict")
 
 
+@pytest.mark.skipif(pytest.skip_torch, reason="requires torch")
 def test_build_spec_onnx(unet2d_nuclei_broad_model):
     _test_build_spec(unet2d_nuclei_broad_model, "onnx")
 
 
+@pytest.mark.skipif(pytest.skip_torch, reason="requires torch")
 def test_build_spec_torchscript(unet2d_nuclei_broad_model):
     _test_build_spec(unet2d_nuclei_broad_model, "pytorch_script")
 

--- a/tests/build_spec/test_build_spec.py
+++ b/tests/build_spec/test_build_spec.py
@@ -57,18 +57,18 @@ def _test_build_spec(path, weight_type, tensorflow_version=None):
 
 
 @pytest.mark.skipif(pytest.skip_torch, reason="requires torch")
-def test_build_spec_pytorch(unet2d_nuclei_broad_model):
-    _test_build_spec(unet2d_nuclei_broad_model, "pytorch_state_dict")
+def test_build_spec_pytorch(any_torch_model):
+    _test_build_spec(any_torch_model, "pytorch_state_dict")
 
 
 @pytest.mark.skipif(pytest.skip_torch, reason="requires torch")
-def test_build_spec_onnx(unet2d_nuclei_broad_model):
-    _test_build_spec(unet2d_nuclei_broad_model, "onnx")
+def test_build_spec_torchscript(any_torchscript_model):
+    _test_build_spec(any_torchscript_model, "pytorch_script")
 
 
-@pytest.mark.skipif(pytest.skip_torch, reason="requires torch")
-def test_build_spec_torchscript(unet2d_nuclei_broad_model):
-    _test_build_spec(unet2d_nuclei_broad_model, "pytorch_script")
+@pytest.mark.skipif(pytest.skip_onnx, reason="requires onnx")
+def test_build_spec_onnx(any_onnx_model):
+    _test_build_spec(any_onnx_model, "onnx")
 
 
 @pytest.mark.skipif(pytest.skip_tensorflow or pytest.tf_major_version != 1, reason="requires tensorflow 1")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,7 @@ def pytest_configure():
     pytest.skip_keras = True  # FruNet requires update
 
     # load all model packages we need for testing
-    load_packages = set()
+    load_packages = {"unet2d_nuclei_broad_model"}  # always load unet2d_nuclei_broad_model
     if not pytest.skip_torch:
         load_packages |= set(torch_models + torchscript_models)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,30 @@
 import pytest
 from bioimageio.core import export_resource_package
 
+# test models for various frameworks
+torch_models = ["unet2d_nuclei_broad_model", "unet2d_multi_tensor"]
+torchscript_models = ["unet2d_nuclei_broad_model", "unet2d_multi_tensor"]
+onnx_models = ["unet2d_nuclei_broad_model", "unet2d_multi_tensor"]
+tensorflow1_models = ["FruNet_model"]
+tensorflow2_models = []
+keras_models = ["FruNet_model"]
+
+model_sources = {
+    "unet2d_nuclei_broad_model": (
+        "https://raw.githubusercontent.com/bioimage-io/spec-bioimage-io/main/example_specs/models/"
+        "unet2d_nuclei_broad/rdf.yaml"
+    ),
+    "unet2d_multi_tensor": (
+        "https://raw.githubusercontent.com/bioimage-io/spec-bioimage-io/main/example_specs/models/"
+        "unet2d_multi_tensor/rdf.yaml"
+    ),
+    "FruNet_model": "https://sandbox.zenodo.org/record/894498/files/rdf.yaml",
+    # "FruNet_model": "https://raw.githubusercontent.com/deepimagej/models/master/fru-net_sev_segmentation/model.yaml",
+}
 
 # set 'skip_<FRAMEWORK>' flags as global pytest variables,
 # to deselect tests that require frameworks not available in current env
 def pytest_configure():
-    try:
-        import tensorflow
-
-        pytest.tf_major_version = int(tensorflow.__version__.split(".")[0])
-    except ImportError:
-        tensorflow = None
-    pytest.skip_tf = tensorflow is None
-
     try:
         import torch
     except ImportError:
@@ -26,37 +38,88 @@ def pytest_configure():
     pytest.skip_onnx = onnxruntime is None
 
     try:
+        import tensorflow
+
+        pytest.tf_major_version = int(tensorflow.__version__.split(".")[0])
+    except ImportError:
+        tensorflow = None
+    pytest.skip_tensorflow = tensorflow is None
+    pytest.skip_tensorflow = True  # todo: update FruNet and remove this
+
+    try:
         import keras
     except ImportError:
         keras = None
     pytest.skip_keras = keras is None
+    pytest.skip_keras = True  # FruNet requires update
 
-    pytest.skip_frunet = True  # disable tests based on fru net for now as it is not expected to pass atm
+    # load all model packages we need for testing
+    load_packages = set()
+    if not pytest.skip_torch:
+        load_packages |= set(torch_models + torchscript_models)
+
+    if not pytest.skip_onnx:
+        load_packages |= set(onnx_models)
+
+    if not pytest.skip_tensorflow and pytest.tf_major_version == 1:
+        load_packages |= set(tensorflow1_models)
+
+    if not pytest.skip_tensorflow and pytest.tf_major_version == 2:
+        load_packages |= set(tensorflow2_models)
+
+    pytest.model_packages = {name: export_resource_package(model_sources[name]) for name in load_packages}
 
 
 @pytest.fixture
 def unet2d_nuclei_broad_model():
-    url = (
-        "https://raw.githubusercontent.com/bioimage-io/spec-bioimage-io/main/example_specs/"
-        "models/unet2d_nuclei_broad/rdf.yaml"
-    )
-    cached_path = export_resource_package(url)
-    return cached_path
+    return pytest.model_packages["unet2d_nuclei_broad_model"]
 
 
 @pytest.fixture
 def unet2d_multi_tensor():
-    url = (
-        "https://raw.githubusercontent.com/bioimage-io/spec-bioimage-io/main/example_specs/"
-        "models/unet2d_multi_tensor/rdf.yaml"
-    )
-    cached_path = export_resource_package(url)
-    return cached_path
+    return pytest.model_packages["unet2d_multi_tensor"]
 
 
 @pytest.fixture
 def FruNet_model():
-    # url = "https://raw.githubusercontent.com/deepimagej/models/master/fru-net_sev_segmentation/model.yaml"
-    url = "https://sandbox.zenodo.org/record/894498/files/rdf.yaml"
-    cached_path = export_resource_package(url)
-    return cached_path
+    return pytest.model_packages["FruNet_model"]
+
+
+#
+# model groups
+#
+
+
+@pytest.fixture(params=torch_models)
+def any_torch_model(request):
+    return pytest.model_packages[request.param]
+
+
+@pytest.fixture(params=torchscript_models)
+def any_torchscript_model(request):
+    return pytest.model_packages[request.param]
+
+
+@pytest.fixture(params=onnx_models)
+def any_onnx_model(request):
+    return pytest.model_packages[request.param]
+
+
+@pytest.fixture(params=tensorflow1_models)
+def any_tensorflow1_model(request):
+    return pytest.model_packages[request.param]
+
+
+@pytest.fixture(params=tensorflow2_models)
+def any_tensorflow2_model(request):
+    return pytest.model_packages[request.param]
+
+
+@pytest.fixture(params=keras_models)
+def any_keras_model(request):
+    return pytest.model_packages[request.param]
+
+
+@pytest.fixture(params=model_sources.keys())
+def any_model(request):
+    return pytest.model_packages[request.param]

--- a/tests/prediction_pipeline/test_prediction_pipeline.py
+++ b/tests/prediction_pipeline/test_prediction_pipeline.py
@@ -19,13 +19,13 @@ def _test_prediction_pipeline(model_package, weight_format):
     tagged_data = [
         xr.DataArray(ipt_tensor, dims=tuple(ipt.axes)) for ipt_tensor, ipt in zip(input_tensors, bio_model.inputs)
     ]
-    output = pp.forward(*tagged_data)
+    outputs = pp.forward(*tagged_data)
+    assert len(outputs) == 1
 
-    expected_outputs = [np.load(opt) for opt in bio_model.test_outputs]
+    expected_outputs = [np.load(str(opt)) for opt in bio_model.test_outputs]
     assert len(expected_outputs) == 1
-    expected_output = expected_outputs[0]
 
-    assert_array_almost_equal(output, expected_output, decimal=4)
+    assert_array_almost_equal(outputs[0], expected_outputs[0], decimal=4)
 
 
 @pytest.mark.skipif(pytest.skip_torch, reason="requires torch")

--- a/tests/prediction_pipeline/test_prediction_pipeline.py
+++ b/tests/prediction_pipeline/test_prediction_pipeline.py
@@ -14,14 +14,17 @@ def _test_prediction_pipeline(model_package, weight_format):
     assert isinstance(bio_model, Model)
     pp = create_prediction_pipeline(bioimageio_model=bio_model, weight_format=weight_format)
 
-    input_tensors = [np.load(str(ipt)) for ipt in bio_model.test_inputs]
-    tagged_data = [
-        xr.DataArray(ipt_tensor, dims=tuple(ipt.axes)) for ipt_tensor, ipt in zip(input_tensors, bio_model.inputs)
+    inputs = [
+        xr.DataArray(np.load(str(test_tensor)), dims=tuple(spec.axes))
+        for test_tensor, spec in zip(bio_model.test_inputs, bio_model.inputs)
     ]
-    outputs = pp.forward(*tagged_data)
+    outputs = pp.forward(*inputs)
     assert isinstance(outputs, list)
 
-    expected_outputs = [np.load(str(opt)) for opt in bio_model.test_outputs]
+    expected_outputs = [
+        xr.DataArray(np.load(str(test_tensor)), dims=tuple(spec.axes))
+        for test_tensor, spec in zip(bio_model.test_outputs, bio_model.outputs)
+    ]
     assert len(outputs) == len(expected_outputs)
 
     for out, exp in zip(outputs, expected_outputs):

--- a/tests/prediction_pipeline/test_prediction_pipeline.py
+++ b/tests/prediction_pipeline/test_prediction_pipeline.py
@@ -34,8 +34,8 @@ def test_prediction_pipeline_torch(any_torch_model):
 
 
 @pytest.mark.skipif(pytest.skip_torch, reason="requires torch")
-def test_prediction_pipeline_torchscript(any_torchsccript_model):
-    _test_prediction_pipeline(any_torchsccript_model, "pytorch_script")
+def test_prediction_pipeline_torchscript(any_torchscript_model):
+    _test_prediction_pipeline(any_torchscript_model, "pytorch_script")
 
 
 @pytest.mark.skipif(pytest.skip_onnx, reason="requires onnx")

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -5,6 +5,8 @@ import pytest
 from bioimageio.core import load_resource_description
 from numpy.testing import assert_array_almost_equal
 
+from bioimageio.core.resource_io.nodes import Model
+
 
 @pytest.mark.skipif(pytest.skip_torch, reason="requires torch")
 def test_test_model(unet2d_nuclei_broad_model):
@@ -35,7 +37,8 @@ def test_predict_image_with_padding(unet2d_nuclei_broad_model, tmp_path):
     from bioimageio.core.prediction import predict_image
 
     spec = load_resource_description(unet2d_nuclei_broad_model)
-    image = np.load(spec.test_inputs[0])[0, 0]
+    assert isinstance(spec, Model)
+    image = np.load(str(spec.test_inputs[0]))[0, 0]
     original_shape = image.shape
     assert image.ndim == 2
 
@@ -73,9 +76,10 @@ def test_predict_image_with_tiling(unet2d_nuclei_broad_model, tmp_path):
     from bioimageio.core.prediction import predict_image
 
     spec = load_resource_description(unet2d_nuclei_broad_model)
+    assert isinstance(spec, Model)
     inputs = spec.test_inputs
     assert len(inputs) == 1
-    exp = np.load(spec.test_outputs[0])
+    exp = np.load(str(spec.test_outputs[0]))
 
     out_path = tmp_path.with_suffix(".npy")
 


### PR DESCRIPTION
This PR adds support for models with multi tensor input and output as the bioimageio RDF defines it.

side note for further/later discussion/development:
`PredictionPipeline` somewhat unnecessarily redefines some parts of  the bioimageio.core.nodes definitions with named/tagged shapes, etc. 
I don't think this slight difference is really justifying the whole redifinition of many fields; instead the implementation of the nodes could be changed or the axis naming, tagging left out here (the axes names are always accessible!). As this would be a bigger change, it is left untouched here and locally `NamedImplicitOutputShape` is defined as a tagged equivalent to `nodes.ImplicitOutputShape`.