### PR TITLE
Multi tensor weight conversion

### DIFF
--- a/bioimageio/core/weight_converter/torch/onnx.py
+++ b/bioimageio/core/weight_converter/torch/onnx.py
@@ -1,4 +1,3 @@
-import os
 import warnings
 from pathlib import Path
 from typing import Union, Optional
@@ -40,15 +39,19 @@ def convert_weights_to_onnx(
     assert isinstance(model_spec, nodes.Model)
     with torch.no_grad():
         # load input and expected output data
-        input_data = np.load(str(model_spec.test_inputs[0])).astype("float32")
-        input_tensor = torch.from_numpy(input_data)
+        input_data = [np.load(inp).astype("float32") for inp in model_spec.test_inputs]
+        input_tensors = [torch.from_numpy(inp) for inp in input_data]
 
         # instantiate and generate the expected output
         model = load_model(model_spec)
-        expected_output = model(input_tensor).numpy()
+        expected_outputs = model(*input_tensors)
+        if isinstance(expected_outputs, torch.Tensor):
+            expected_outputs = [expected_outputs]
+        expected_outputs = [out.numpy() for out in expected_outputs]
 
         if use_tracing:
-            torch.onnx.export(model, input_tensor, output_path, verbose=verbose, opset_version=opset_version)
+            torch.onnx.export(model, input_tensors, output_path, verbose=verbose, opset_version=opset_version,
+                              example_outputs=expected_outputs)
         else:
             raise NotImplementedError
 
@@ -59,11 +62,12 @@ def convert_weights_to_onnx(
 
         # check the onnx model
         sess = rt.InferenceSession(str(output_path))  # does not support Path, so need to cast to str
-        input_name = sess.get_inputs()[0].name
-        output = sess.run(None, {input_name: input_data})[0]
+        onnx_inputs = {input_name.name: inp for input_name, inp in zip(sess.get_inputs(), input_data)}
+        outputs = sess.run(None, onnx_inputs)
 
         try:
-            assert_array_almost_equal(expected_output, output, decimal=4)
+            for exp, out in zip(expected_outputs, outputs):
+                assert_array_almost_equal(exp, out, decimal=4)
             return 0
         except AssertionError as e:
             msg = f"The onnx weights were exported, but results before and after conversion do not agree:\n {str(e)}"

--- a/bioimageio/core/weight_converter/torch/onnx.py
+++ b/bioimageio/core/weight_converter/torch/onnx.py
@@ -50,8 +50,14 @@ def convert_weights_to_onnx(
         expected_outputs = [out.numpy() for out in expected_outputs]
 
         if use_tracing:
-            torch.onnx.export(model, input_tensors, output_path, verbose=verbose, opset_version=opset_version,
-                              example_outputs=expected_outputs)
+            torch.onnx.export(
+                model,
+                input_tensors if len(input_tensors) > 1 else input_tensors[0],
+                output_path,
+                verbose=verbose,
+                opset_version=opset_version,
+                example_outputs=expected_outputs,
+            )
         else:
             raise NotImplementedError
 

--- a/bioimageio/core/weight_converter/torch/torchscript.py
+++ b/bioimageio/core/weight_converter/torch/torchscript.py
@@ -37,8 +37,9 @@ def _check_predictions(model, scripted_model, model_spec, input_data):
             return 1
 
     ret = _check(input_data)
-    # check has not passed? then return immediately
-    if ret == 1:
+    n_inputs = len(model_spec.inputs)
+    # check has not passed or we have more tahn one input? then return immediately
+    if ret == 1 or n_inputs > 1:
         return ret
 
     # do we have fixed input size or variable?
@@ -58,8 +59,8 @@ def _check_predictions(model, scripted_model, model_spec, input_data):
     while True:
 
         slice_ = tuple(slice(None) if st == 0 else slice(step_factor * st, -step_factor * st) for st in half_step)
-        this_input = input_data[slice_]
-        this_shape = this_input.shape
+        this_input = [inp[slice_] for inp in input_data]
+        this_shape = this_input[0].shape
         if any(tsh < msh for tsh, msh in zip(this_shape, min_shape)):
             return ret
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,16 @@ def unet2d_nuclei_broad_model():
 
 
 @pytest.fixture
+def unet2d_multi_tensor():
+    url = (
+        "https://raw.githubusercontent.com/bioimage-io/spec-bioimage-io/main/example_specs/"
+        "models/unet2d_multi_tensor/rdf.yaml"
+    )
+    cached_path = export_resource_package(url)
+    return cached_path
+
+
+@pytest.fixture
 def FruNet_model():
     # url = "https://raw.githubusercontent.com/deepimagej/models/master/fru-net_sev_segmentation/model.yaml"
     url = "https://sandbox.zenodo.org/record/894498/files/rdf.yaml"

--- a/tests/weight_converter/torch/test_onnx.py
+++ b/tests/weight_converter/torch/test_onnx.py
@@ -3,13 +3,22 @@ import pytest
 
 
 @pytest.mark.skipif(pytest.skip_torch, reason="requires pytorch")
-def test_torchscript_converter(unet2d_nuclei_broad_model, tmp_path):
+def test_onnx_converter(unet2d_nuclei_broad_model, tmp_path):
     from bioimageio.core.weight_converter.torch.onnx import convert_weights_to_onnx
 
     out_path = tmp_path / "weights.onnx"
-    convert_weights_to_onnx(unet2d_nuclei_broad_model, out_path)
+    ret_val = convert_weights_to_onnx(unet2d_nuclei_broad_model, out_path)
     assert os.path.exists(out_path)
-
-    # TODO check that weights can be loaded and results agree if we have onnx runtime
     if not pytest.skip_onnx:
-        pass
+        assert ret_val == 0  # check for correctness is done in converter and returns 0 if it passes
+
+
+@pytest.mark.skipif(pytest.skip_torch, reason="requires pytorch")
+def test_onnx_converter_multi_tensor(unet2d_multi_tensor, tmp_path):
+    from bioimageio.core.weight_converter.torch.onnx import convert_weights_to_onnx
+
+    out_path = tmp_path / "weights.onnx"
+    ret_val = convert_weights_to_onnx(unet2d_multi_tensor, out_path)
+    assert os.path.exists(out_path)
+    if not pytest.skip_onnx:
+        assert ret_val == 0  # check for correctness is done in converter and returns 0 if it passes

--- a/tests/weight_converter/torch/test_torchscript.py
+++ b/tests/weight_converter/torch/test_torchscript.py
@@ -7,6 +7,16 @@ def test_torchscript_converter(unet2d_nuclei_broad_model, tmp_path):
     from bioimageio.core.weight_converter.torch import convert_weights_to_pytorch_script
 
     out_path = tmp_path / "weights.pt"
-    convert_weights_to_pytorch_script(unet2d_nuclei_broad_model, out_path)
+    ret_val = convert_weights_to_pytorch_script(unet2d_nuclei_broad_model, out_path)
     assert os.path.exists(out_path)
-    # TODO check results for correctness
+    assert ret_val == 0  # check for correctness is done in converter and returns 0 if it passes
+
+
+@pytest.mark.skipif(pytest.skip_torch, reason="requires pytorch")
+def test_torchscript_converter_multi_tensor(unet2d_multi_tensor, tmp_path):
+    from bioimageio.core.weight_converter.torch import convert_weights_to_pytorch_script
+
+    out_path = tmp_path / "weights.pt"
+    ret_val = convert_weights_to_pytorch_script(unet2d_multi_tensor, out_path)
+    assert os.path.exists(out_path)
+    assert ret_val == 0  # check for correctness is done in converter and returns 0 if it passes


### PR DESCRIPTION
Implement support for multiple input / output tensors in weight converter.
@FynnBe the changes in `conftest.py` are also relevant for #103. Also, I have added torchscript and onnx weights to the multi-tensor models, so you can test prediction with them.